### PR TITLE
29 filter arbitragy that meet premium standard by fee rate

### DIFF
--- a/pytradekit/trading_setup/exchange_fees.py
+++ b/pytradekit/trading_setup/exchange_fees.py
@@ -1,0 +1,323 @@
+"""
+Exchange fee data and calculator module.
+
+This module contains complete fee structures for major exchanges (Binance, Huobi, OKX)
+and provides FeeCalculator class for calculating trading fees based on account configurations.
+"""
+
+from typing import Dict, Optional, Any
+from decimal import Decimal
+from pytradekit.utils.config_agent import ConfigAgent
+from pytradekit.utils.exceptions import DependencyException
+from pytradekit.utils.dynamic_types import ExchangeId, InstCodeType
+from pytradekit.utils.static_types import FeeConfigAttribute, FeeStructureKey
+
+
+EXCHANGE_FEES: Dict[str, Dict[str, Any]] = {
+    ExchangeId.BN.name: {  # Binance
+        InstCodeType.SPOT.name: {
+            FeeStructureKey.vip_levels.name: {
+                # VIP 0: 30-day trading volume < 1,000,000 USD
+                0: {FeeStructureKey.maker.name: 0.001, FeeStructureKey.taker.name: 0.001},
+                # VIP 1: 30-day trading volume >= 1,000,000 USD and hold >= 25 BNB
+                1: {FeeStructureKey.maker.name: 0.0009, FeeStructureKey.taker.name: 0.001},
+                # VIP 2: 30-day trading volume >= 5,000,000 USD and hold >= 100 BNB
+                2: {FeeStructureKey.maker.name: 0.0008, FeeStructureKey.taker.name: 0.001},
+                # VIP 3: 30-day trading volume >= 20,000,000 USD and hold >= 250 BNB
+                3: {FeeStructureKey.maker.name: 0.0004, FeeStructureKey.taker.name: 0.0006},
+                # VIP 4: 30-day trading volume >= 50,000,000 USD and hold >= 500 BNB
+                4: {FeeStructureKey.maker.name: 0.0002, FeeStructureKey.taker.name: 0.0004},
+                # VIP 5: 30-day trading volume >= 100,000,000 USD and hold >= 1,000 BNB
+                5: {FeeStructureKey.maker.name: 0.0001, FeeStructureKey.taker.name: 0.0003},
+                # VIP 6: 30-day trading volume >= 200,000,000 USD and hold >= 2,500 BNB
+                6: {FeeStructureKey.maker.name: 0.00008, FeeStructureKey.taker.name: 0.00025},
+                # VIP 7: 30-day trading volume >= 500,000,000 USD and hold >= 5,000 BNB
+                7: {FeeStructureKey.maker.name: 0.00005, FeeStructureKey.taker.name: 0.0002},
+                # VIP 8: 30-day trading volume >= 1,000,000,000 USD and hold >= 10,000 BNB
+                8: {FeeStructureKey.maker.name: 0.00002, FeeStructureKey.taker.name: 0.00015},
+                # VIP 9: 30-day trading volume >= 2,000,000,000 USD and hold >= 20,000 BNB
+                9: {FeeStructureKey.maker.name: 0.0, FeeStructureKey.taker.name: 0.0001},
+            },
+            FeeStructureKey.discounts.name: {
+                FeeStructureKey.platform_token_discount.name: 0.25, 
+                FeeStructureKey.platform_token.name: 'BNB',  # Platform token name
+                FeeStructureKey.holding_discount.name: {}
+            }
+        },
+        InstCodeType.PERP.name: {
+            FeeStructureKey.vip_levels.name: {
+                # Perpetual futures fees (similar structure to spot)
+                0: {FeeStructureKey.maker.name: 0.0002, FeeStructureKey.taker.name: 0.0005},
+                1: {FeeStructureKey.maker.name: 0.00016, FeeStructureKey.taker.name: 0.0004},
+                2: {FeeStructureKey.maker.name: 0.00014, FeeStructureKey.taker.name: 0.00035},
+                3: {FeeStructureKey.maker.name: 0.00012, FeeStructureKey.taker.name: 0.00032},
+                4: {FeeStructureKey.maker.name: 0.0001, FeeStructureKey.taker.name: 0.0003},
+                5: {FeeStructureKey.maker.name: 0.00008, FeeStructureKey.taker.name: 0.00025},
+                6: {FeeStructureKey.maker.name: 0.00006, FeeStructureKey.taker.name: 0.00022},
+                7: {FeeStructureKey.maker.name: 0.00004, FeeStructureKey.taker.name: 0.0002},
+                8: {FeeStructureKey.maker.name: 0.00002, FeeStructureKey.taker.name: 0.00018},
+                9: {FeeStructureKey.maker.name: 0.0, FeeStructureKey.taker.name: 0.00016},
+            },
+            FeeStructureKey.discounts.name: {
+                FeeStructureKey.platform_token_discount.name: 0.1, 
+                FeeStructureKey.platform_token.name: 'BNB',
+                FeeStructureKey.holding_discount.name: {}
+            }
+        }
+    },
+    ExchangeId.HTX.name: {  # Huobi (HTX)
+        InstCodeType.SPOT.name: {
+            FeeStructureKey.vip_levels.name: {
+                # VIP 0: Regular user
+                0: {FeeStructureKey.maker.name: 0.002, FeeStructureKey.taker.name: 0.002},
+                # VIP 1
+                1: {FeeStructureKey.maker.name: 0.0016, FeeStructureKey.taker.name: 0.0017},
+                # VIP 2
+                2: {FeeStructureKey.maker.name: 0.0014, FeeStructureKey.taker.name: 0.0015},
+                # VIP 3
+                3: {FeeStructureKey.maker.name: 0.001, FeeStructureKey.taker.name: 0.001},
+                # VIP 4
+                4: {FeeStructureKey.maker.name: 0.0008, FeeStructureKey.taker.name: 0.001},
+                # VIP 5
+                5: {FeeStructureKey.maker.name: 0.0006, FeeStructureKey.taker.name: 0.0009},
+            },
+            FeeStructureKey.discounts.name: {
+                FeeStructureKey.platform_token_discount.name: 0.25,  # 20% discount when using HT to pay fees
+                FeeStructureKey.platform_token.name: 'HTX',  # Platform token name
+                FeeStructureKey.holding_discount.name: {}
+            }
+        },
+        InstCodeType.PERP.name: {
+            FeeStructureKey.vip_levels.name: {
+                # Perpetual futures fees
+                0: {FeeStructureKey.maker.name: 0.0002, FeeStructureKey.taker.name: 0.0006},
+                1: {FeeStructureKey.maker.name: 0.00018, FeeStructureKey.taker.name: 0.00055},
+                2: {FeeStructureKey.maker.name: 0.00016, FeeStructureKey.taker.name: 0.0005},
+                3: {FeeStructureKey.maker.name: 0.00014, FeeStructureKey.taker.name: 0.00045},
+                4: {FeeStructureKey.maker.name: 0.00012, FeeStructureKey.taker.name: 0.0004},
+                5: {FeeStructureKey.maker.name: 0.0001, FeeStructureKey.taker.name: 0.00038},
+            },
+            FeeStructureKey.discounts.name: {
+                FeeStructureKey.platform_token_discount.name: 0.05,  # 20% discount when using HT to pay fees
+                FeeStructureKey.platform_token.name: 'HT',
+                FeeStructureKey.holding_discount.name: {}
+            }
+        }
+    },
+    ExchangeId.OKX.name: {  # OKX
+        InstCodeType.SPOT.name: {
+            FeeStructureKey.vip_levels.name: {
+                # VIP 0: Regular user
+                0: {FeeStructureKey.maker.name: 0.0008, FeeStructureKey.taker.name: 0.001},
+                # VIP 1
+                1: {FeeStructureKey.maker.name: 0.00045, FeeStructureKey.taker.name: 0.0005},
+                # VIP 2
+                2: {FeeStructureKey.maker.name: 0.0004, FeeStructureKey.taker.name: 0.00045},
+                # VIP 3
+                3: {FeeStructureKey.maker.name: 0.0003, FeeStructureKey.taker.name: 0.0004},
+                # VIP 4
+                4: {FeeStructureKey.maker.name: 0.0002, FeeStructureKey.taker.name: 0.00035},
+                # VIP 5
+                5: {FeeStructureKey.maker.name: 0.00000, FeeStructureKey.taker.name: 0.0003},
+            },
+            FeeStructureKey.discounts.name: {
+                FeeStructureKey.platform_token_discount.name: 0,  # 20% discount when using OKB to pay fees
+                FeeStructureKey.platform_token.name: None,  # Platform token name
+                FeeStructureKey.holding_discount.name: {}
+            }
+        },
+        InstCodeType.PERP.name: {
+            FeeStructureKey.vip_levels.name: {
+                # Perpetual futures fees
+                0: {FeeStructureKey.maker.name: 0.0002, FeeStructureKey.taker.name: 0.0005},
+                1: {FeeStructureKey.maker.name: 0.00015, FeeStructureKey.taker.name: 0.0004},
+                2: {FeeStructureKey.maker.name: 0.0001, FeeStructureKey.taker.name: 0.00035},
+                3: {FeeStructureKey.maker.name: 0.00008, FeeStructureKey.taker.name: 0.0003},
+                4: {FeeStructureKey.maker.name: 0.00005, FeeStructureKey.taker.name: 0.00025},
+                5: {FeeStructureKey.maker.name: 0.00002, FeeStructureKey.taker.name: 0.0002},
+            },
+            FeeStructureKey.discounts.name: {
+                FeeStructureKey.platform_token_discount.name: 0 , # 20% discount when using OKB to pay fees
+                FeeStructureKey.platform_token.name: None,
+                FeeStructureKey.holding_discount.name: {}
+            }
+        }
+    }
+}
+
+
+class FeeCalculator:
+    """
+    Calculate trading fees based on exchange fee structure and account configuration.
+    
+    Supports:
+    - VIP level discounts
+    - Platform token discounts (BNB, HT, OKB, etc.)
+    - Holding discounts
+    - Maker/Taker fee rates
+    """
+
+    def __init__(self, config: Optional[ConfigAgent] = None):
+        """
+        Initialize FeeCalculator.
+
+        Args:
+            config: ConfigAgent instance for reading account fee configurations
+        """
+        self.config = config
+        self.exchange_fees = EXCHANGE_FEES
+
+    def _get_account_fee_config(
+        self,
+        account_id: str,
+        exchange_id: str
+    ) -> Dict[str, Any]:
+        """
+        Get account-specific fee configuration from config file.
+
+        Args:
+            account_id: Account ID
+            exchange_id: Exchange ID (BN, HTX, OKX, etc.)
+
+        Returns:
+            Dictionary containing account fee configuration:
+            {
+                FeeConfigAttribute.vip_level.name: int,
+                FeeConfigAttribute.use_platform_token_discount.name: bool,
+                FeeConfigAttribute.holding_discount.name: bool
+            }
+        """
+        default_config = {
+            FeeConfigAttribute.vip_level.name: 0,
+            FeeConfigAttribute.use_platform_token_discount.name: False,
+            FeeConfigAttribute.holding_discount.name: False
+        }
+
+        if self.config is None or self.config.outer is None:
+            return default_config
+
+        # Section name format: {EXCHANGE_ID}_ACCOUNT
+        section_name = f"{exchange_id}_ACCOUNT"
+
+        try:
+            # Check if section exists
+            if section_name not in self.config.outer.sections():
+                return default_config
+
+            # Get account_id from config
+            config_account_id = ConfigAgent.get_str(
+                self.config.outer,
+                section_name,
+                FeeConfigAttribute.account_id.name
+            )
+
+            # Only return config if account_id matches
+            if config_account_id != account_id:
+                return default_config
+
+            # Read configuration
+            vip_level = ConfigAgent.get_int(
+                self.config.outer,
+                section_name,
+                FeeConfigAttribute.vip_level.name
+            )
+            use_platform_token_discount = ConfigAgent.get_boolean(
+                self.config.outer,
+                section_name,
+                FeeConfigAttribute.use_platform_token_discount.name
+            )
+            holding_discount = ConfigAgent.get_boolean(
+                self.config.outer,
+                section_name,
+                FeeConfigAttribute.holding_discount.name
+            )
+
+            return {
+                FeeConfigAttribute.vip_level.name: vip_level,
+                FeeConfigAttribute.use_platform_token_discount.name: use_platform_token_discount,
+                FeeConfigAttribute.holding_discount.name: holding_discount
+            }
+        except Exception:
+            # Return default config if any error occurs
+            return default_config
+
+    def get_fee_rate(
+        self,
+        account_id: str,
+        exchange_id: str,
+        market_type: str,
+        is_maker: bool
+    ) -> float:
+        """
+        Get fee rate for given account and trading parameters.
+
+        Args:
+            account_id: Account ID
+            exchange_id: Exchange ID (BN, HTX, OKX, etc.)
+            market_type: Market type ('spot' or 'perp')
+            is_maker: True for maker order, False for taker order
+
+        Returns:
+            Fee rate as float (e.g., 0.001 for 0.1%)
+
+        Raises:
+            DependencyException: If exchange or market type not found
+        """
+        # Get exchange fee structure
+        if exchange_id not in self.exchange_fees:
+            raise DependencyException(
+                f"Exchange {exchange_id} not found in fee structure"
+            )
+
+        exchange_data = self.exchange_fees[exchange_id]
+
+        if market_type not in exchange_data:
+            raise DependencyException(
+                f"Market type {market_type} not found for exchange {exchange_id}"
+            )
+
+        market_data = exchange_data[market_type]
+
+        # Get account configuration
+        account_config = self._get_account_fee_config(account_id, exchange_id)
+        vip_level = account_config[FeeConfigAttribute.vip_level.name]
+
+        # Get base fee rate from VIP level
+        vip_levels_key = FeeStructureKey.vip_levels.name
+        if vip_level not in market_data[vip_levels_key]:
+            # Use level 0 as default if VIP level not found
+            vip_level = 0
+            if vip_level not in market_data[vip_levels_key]:
+                raise DependencyException(
+                    f"VIP level {vip_level} not found for {exchange_id} {market_type}"
+                )
+
+        fee_type = FeeStructureKey.maker.name if is_maker else FeeStructureKey.taker.name
+        base_fee_rate = market_data[vip_levels_key][vip_level][fee_type]
+
+        # Apply discounts
+        final_fee_rate = base_fee_rate
+
+        # Apply platform token discount
+        discounts_key = FeeStructureKey.discounts.name
+        if account_config[FeeConfigAttribute.use_platform_token_discount.name]:
+            platform_token_discount = market_data[discounts_key].get(
+                FeeStructureKey.platform_token_discount.name,
+                0.0
+            )
+            final_fee_rate = final_fee_rate * (1 - platform_token_discount)
+
+        # Apply holding discount (if applicable)
+        if account_config[FeeConfigAttribute.holding_discount.name]:
+            holding_discount_data = market_data[discounts_key].get(
+                FeeStructureKey.holding_discount.name,
+                {}
+            )
+            if holding_discount_data:
+                holding_discount_rate = holding_discount_data.get(
+                    'discount_rate',
+                    0.0
+                )
+                final_fee_rate = final_fee_rate * (1 - holding_discount_rate)
+
+        return float(final_fee_rate)

--- a/pytradekit/trading_setup/websocket_restart_config.py
+++ b/pytradekit/trading_setup/websocket_restart_config.py
@@ -1,2 +1,2 @@
-class WebsocketRestartSeconds:
+class WebsocketRestartSeconds: ## TODO 这个有用吗？ 如果有用换个地方
     BN_order_book = 60

--- a/pytradekit/utils/static_types.py
+++ b/pytradekit/utils/static_types.py
@@ -1086,3 +1086,28 @@ class ArbitragePoolsReport:
             else:
                 result[slot] = value
         return result
+
+
+class FeeDiscountType(Enum):
+    """Fee discount types."""
+    platform_token_discount = auto()  # Platform token discount (BNB, HT, OKB, etc.)
+    holding_discount = auto()  # Holding discount
+
+
+class FeeStructureKey(Enum):
+    """Keys used in exchange fee structure dictionary."""
+    vip_levels = auto()
+    discounts = auto()
+    platform_token_discount = auto()
+    platform_token = auto()
+    holding_discount = auto()
+    maker = auto()
+    taker = auto()
+
+
+class FeeConfigAttribute(Enum):
+    """Fee configuration attributes for account settings."""
+    account_id = auto()
+    vip_level = auto()
+    use_platform_token_discount = auto()
+    holding_discount = auto()

--- a/pytradekit/utils/static_types.py
+++ b/pytradekit/utils/static_types.py
@@ -1107,7 +1107,7 @@ class FeeStructureKey(Enum):
 
 class FeeConfigAttribute(Enum):
     """Fee configuration attributes for account settings."""
-    account_id = auto()
-    vip_level = auto()
-    use_platform_token_discount = auto()
-    holding_discount = auto()
+    ACCOUNT_ID = auto()
+    VIP_LEVEL = auto()
+    USE_PLATFORM_TOKEN_DISCOUNT = auto()
+    HOLDING_DISCOUNT = auto()

--- a/tests/test_exchange_fees.py
+++ b/tests/test_exchange_fees.py
@@ -4,31 +4,35 @@ Tests for exchange fees module.
 
 import pytest
 from unittest.mock import Mock, MagicMock, patch
-from pytradekit.trading_setup.exchange_fees import FeeCalculator, EXCHANGE_FEES
+from pytradekit.trading_setup.exchange_fees import FeeRateResolver, EXCHANGE_FEES
 from pytradekit.utils.config_agent import ConfigAgent
 from pytradekit.utils.exceptions import DependencyException
 
 
-class TestFeeCalculator:
-    """Test FeeCalculator class."""
+class TestFeeRateResolver:
+
+    """Test FeeRateResolver class."""
 
     def test_init_without_config(self):
-        """Test FeeCalculator initialization without config."""
-        calculator = FeeCalculator()
+        """Test FeeRateResolver initialization without config."""
+        logger = Mock()
+        calculator = FeeRateResolver(logger=logger)
         assert calculator.config is None
         assert calculator.exchange_fees == EXCHANGE_FEES
 
     def test_init_with_config(self):
-        """Test FeeCalculator initialization with config."""
+        """Test FeeRateResolver initialization with config."""
+        logger = Mock()
         config = Mock(spec=ConfigAgent)
-        calculator = FeeCalculator(config)
+        calculator = FeeRateResolver(logger=logger, config=config)
         assert calculator.config == config
         assert calculator.exchange_fees == EXCHANGE_FEES
 
     def test_get_account_fee_config_no_config(self):
         """Test getting account fee config when no config provided."""
-        calculator = FeeCalculator()
-        config = calculator._get_account_fee_config('BN_000', 'BN')
+        logger = Mock()
+        calculator = FeeRateResolver(logger=logger)
+        config = calculator._get_account_fee_config('BN')
         assert config == {
             'vip_level': 0,
             'use_platform_token_discount': False,
@@ -37,6 +41,7 @@ class TestFeeCalculator:
 
     def test_get_account_fee_config_with_config(self):
         """Test getting account fee config from config file."""
+        logger = Mock()
         config = Mock(spec=ConfigAgent)
         config.outer = MagicMock()
         config.outer.sections.return_value = ['BN_ACCOUNT']
@@ -47,27 +52,28 @@ class TestFeeCalculator:
             'holding_discount': 'false'
         }[key]
 
-        calculator = FeeCalculator(config)
+        calculator = FeeRateResolver(logger=logger, config=config)
         
         # Mock ConfigAgent static methods
         with patch.object(ConfigAgent, 'get_str', return_value='BN_000'), \
              patch.object(ConfigAgent, 'get_int', return_value=1), \
              patch.object(ConfigAgent, 'get_boolean', side_effect=[True, False]):
-            result = calculator._get_account_fee_config('BN_000', 'BN')
+            result = calculator._get_account_fee_config('BN')
             assert result['vip_level'] == 1
             assert result['use_platform_token_discount'] is True
             assert result['holding_discount'] is False
 
     def test_get_account_fee_config_wrong_account_id(self):
         """Test getting account fee config with wrong account_id."""
+        logger = Mock()
         config = Mock(spec=ConfigAgent)
         config.outer = MagicMock()
         config.outer.sections.return_value = ['BN_ACCOUNT']
         
-        calculator = FeeCalculator(config)
+        calculator = FeeRateResolver(logger=logger, config=config)
         
         with patch.object(ConfigAgent, 'get_str', return_value='BN_001'):  # Different account_id
-            result = calculator._get_account_fee_config('BN_000', 'BN')
+            result = calculator._get_account_fee_config('BN')
             # Should return default config
             assert result == {
                 'vip_level': 0,
@@ -77,9 +83,10 @@ class TestFeeCalculator:
 
     def test_get_fee_rate_exchange_not_found(self):
         """Test get_fee_rate with non-existent exchange."""
-        calculator = FeeCalculator()
+        logger = Mock()
+        calculator = FeeRateResolver(logger=logger)
         with pytest.raises(DependencyException) as exc_info:
-            calculator.get_fee_rate('BN_000', 'INVALID', 'spot', True)
+            calculator.get_fee_rate('INVALID', 'spot', True)
         assert 'Exchange INVALID not found' in str(exc_info.value)
 
     def test_get_fee_rate_market_type_not_found(self):
@@ -91,11 +98,12 @@ class TestFeeCalculator:
                 'discounts': {'platform_token_discount': 0.25, 'platform_token': 'TEST'}
             }
         }
-        calculator = FeeCalculator()
+        logger = Mock()
+        calculator = FeeRateResolver(logger=logger)
         calculator.exchange_fees['TEST'] = test_exchange
         
         with pytest.raises(DependencyException) as exc_info:
-            calculator.get_fee_rate('TEST_000', 'TEST', 'invalid', True)
+            calculator.get_fee_rate('TEST', 'invalid', True)
         assert 'Market type invalid not found' in str(exc_info.value)
 
     def test_get_fee_rate_vip_level_not_found(self):
@@ -106,11 +114,12 @@ class TestFeeCalculator:
                 'discounts': {'platform_token_discount': 0.25, 'platform_token': 'TEST'}
             }
         }
-        calculator = FeeCalculator()
+        logger = Mock()
+        calculator = FeeRateResolver(logger=logger)
         calculator.exchange_fees['TEST'] = test_exchange
         
         # Should fallback to level 0 if VIP level not found
-        rate = calculator.get_fee_rate('TEST_000', 'TEST', 'spot', True)
+        rate = calculator.get_fee_rate('TEST', 'spot', True)
         assert rate == 0.001
 
     def test_get_fee_rate_maker(self):
@@ -128,10 +137,11 @@ class TestFeeCalculator:
                 }
             }
         }
-        calculator = FeeCalculator()
+        logger = Mock()
+        calculator = FeeRateResolver(logger=logger)
         calculator.exchange_fees['TEST'] = test_exchange
         
-        rate = calculator.get_fee_rate('TEST_000', 'TEST', 'spot', True)
+        rate = calculator.get_fee_rate('TEST', 'spot', True)
         assert rate == 0.001
 
     def test_get_fee_rate_taker(self):
@@ -149,10 +159,11 @@ class TestFeeCalculator:
                 }
             }
         }
-        calculator = FeeCalculator()
+        logger = Mock()
+        calculator = FeeRateResolver(logger=logger)
         calculator.exchange_fees['TEST'] = test_exchange
         
-        rate = calculator.get_fee_rate('TEST_000', 'TEST', 'spot', False)
+        rate = calculator.get_fee_rate('TEST', 'spot', False)
         assert rate == 0.001
 
     def test_get_fee_rate_with_platform_token_discount(self):
@@ -169,7 +180,8 @@ class TestFeeCalculator:
                 }
             }
         }
-        calculator = FeeCalculator()
+        logger = Mock()
+        calculator = FeeRateResolver(logger=logger)
         calculator.exchange_fees['TEST'] = test_exchange
         
         # Mock config to enable platform token discount
@@ -187,7 +199,7 @@ class TestFeeCalculator:
                 'holding_discount': False
             }
         ):
-            rate = calculator.get_fee_rate('TEST_000', 'TEST', 'spot', True)
+            rate = calculator.get_fee_rate('TEST', 'spot', True)
             # 0.001 * (1 - 0.25) = 0.00075
             assert rate == 0.00075
 
@@ -205,7 +217,8 @@ class TestFeeCalculator:
                 }
             }
         }
-        calculator = FeeCalculator()
+        logger = Mock()
+        calculator = FeeRateResolver(logger=logger)
         calculator.exchange_fees['TEST'] = test_exchange
         
         config = Mock(spec=ConfigAgent)
@@ -222,7 +235,7 @@ class TestFeeCalculator:
                 'holding_discount': True
             }
         ):
-            rate = calculator.get_fee_rate('TEST_000', 'TEST', 'spot', True)
+            rate = calculator.get_fee_rate('TEST', 'spot', True)
             # 0.001 * (1 - 0.1) = 0.0009
             assert rate == 0.0009
 
@@ -240,7 +253,8 @@ class TestFeeCalculator:
                 }
             }
         }
-        calculator = FeeCalculator()
+        logger = Mock()
+        calculator = FeeRateResolver(logger=logger)
         calculator.exchange_fees['TEST'] = test_exchange
         
         config = Mock(spec=ConfigAgent)
@@ -257,75 +271,7 @@ class TestFeeCalculator:
                 'holding_discount': True
             }
         ):
-            rate = calculator.get_fee_rate('TEST_000', 'TEST', 'spot', True)
+            rate = calculator.get_fee_rate('TEST', 'spot', True)
             # 0.001 * (1 - 0.25) * (1 - 0.1) = 0.000675
             assert rate == pytest.approx(0.000675)
-
-    def test_calculate_fee(self):
-        """Test calculate_fee method."""
-        test_exchange = {
-            'spot': {
-                'vip_levels': {
-                    0: {'maker': 0.001, 'taker': 0.001}
-                },
-                'discounts': {
-                    'platform_token_discount': 0.25,
-                    'platform_token': 'TEST',
-                    'holding_discount': {}
-                }
-            }
-        }
-        calculator = FeeCalculator()
-        calculator.exchange_fees['TEST'] = test_exchange
-        
-        fee = calculator.calculate_fee(
-            account_id='TEST_000',
-            exchange_id='TEST',
-            market_type='spot',
-            is_maker=True,
-            trade_amount=10000.0
-        )
-        # 10000 * 0.001 = 10
-        assert fee == 10.0
-
-    def test_calculate_fee_with_discount(self):
-        """Test calculate_fee with discount."""
-        test_exchange = {
-            'spot': {
-                'vip_levels': {
-                    0: {'maker': 0.001, 'taker': 0.001}
-                },
-                'discounts': {
-                    'platform_token_discount': 0.25,
-                    'platform_token': 'TEST',
-                    'holding_discount': {}
-                }
-            }
-        }
-        calculator = FeeCalculator()
-        calculator.exchange_fees['TEST'] = test_exchange
-        
-        config = Mock(spec=ConfigAgent)
-        config.outer = MagicMock()
-        config.outer.sections.return_value = ['TEST_ACCOUNT']
-        calculator.config = config
-        
-        with patch.object(
-            calculator,
-            '_get_account_fee_config',
-            return_value={
-                'vip_level': 0,
-                'use_platform_token_discount': True,
-                'holding_discount': False
-            }
-        ):
-            fee = calculator.calculate_fee(
-                account_id='TEST_000',
-                exchange_id='TEST',
-                market_type='spot',
-                is_maker=True,
-                trade_amount=10000.0
-            )
-            # 10000 * 0.001 * (1 - 0.25) = 7.5
-            assert fee == 7.5
 

--- a/tests/test_exchange_fees.py
+++ b/tests/test_exchange_fees.py
@@ -1,0 +1,331 @@
+"""
+Tests for exchange fees module.
+"""
+
+import pytest
+from unittest.mock import Mock, MagicMock, patch
+from pytradekit.trading_setup.exchange_fees import FeeCalculator, EXCHANGE_FEES
+from pytradekit.utils.config_agent import ConfigAgent
+from pytradekit.utils.exceptions import DependencyException
+
+
+class TestFeeCalculator:
+    """Test FeeCalculator class."""
+
+    def test_init_without_config(self):
+        """Test FeeCalculator initialization without config."""
+        calculator = FeeCalculator()
+        assert calculator.config is None
+        assert calculator.exchange_fees == EXCHANGE_FEES
+
+    def test_init_with_config(self):
+        """Test FeeCalculator initialization with config."""
+        config = Mock(spec=ConfigAgent)
+        calculator = FeeCalculator(config)
+        assert calculator.config == config
+        assert calculator.exchange_fees == EXCHANGE_FEES
+
+    def test_get_account_fee_config_no_config(self):
+        """Test getting account fee config when no config provided."""
+        calculator = FeeCalculator()
+        config = calculator._get_account_fee_config('BN_000', 'BN')
+        assert config == {
+            'vip_level': 0,
+            'use_platform_token_discount': False,
+            'holding_discount': False
+        }
+
+    def test_get_account_fee_config_with_config(self):
+        """Test getting account fee config from config file."""
+        config = Mock(spec=ConfigAgent)
+        config.outer = MagicMock()
+        config.outer.sections.return_value = ['BN_ACCOUNT']
+        config.outer.__getitem__ = lambda self, key: {
+            'account_id': 'BN_000',
+            'vip_level': '1',
+            'use_platform_token_discount': 'true',
+            'holding_discount': 'false'
+        }[key]
+
+        calculator = FeeCalculator(config)
+        
+        # Mock ConfigAgent static methods
+        with patch.object(ConfigAgent, 'get_str', return_value='BN_000'), \
+             patch.object(ConfigAgent, 'get_int', return_value=1), \
+             patch.object(ConfigAgent, 'get_boolean', side_effect=[True, False]):
+            result = calculator._get_account_fee_config('BN_000', 'BN')
+            assert result['vip_level'] == 1
+            assert result['use_platform_token_discount'] is True
+            assert result['holding_discount'] is False
+
+    def test_get_account_fee_config_wrong_account_id(self):
+        """Test getting account fee config with wrong account_id."""
+        config = Mock(spec=ConfigAgent)
+        config.outer = MagicMock()
+        config.outer.sections.return_value = ['BN_ACCOUNT']
+        
+        calculator = FeeCalculator(config)
+        
+        with patch.object(ConfigAgent, 'get_str', return_value='BN_001'):  # Different account_id
+            result = calculator._get_account_fee_config('BN_000', 'BN')
+            # Should return default config
+            assert result == {
+                'vip_level': 0,
+                'use_platform_token_discount': False,
+                'holding_discount': False
+            }
+
+    def test_get_fee_rate_exchange_not_found(self):
+        """Test get_fee_rate with non-existent exchange."""
+        calculator = FeeCalculator()
+        with pytest.raises(DependencyException) as exc_info:
+            calculator.get_fee_rate('BN_000', 'INVALID', 'spot', True)
+        assert 'Exchange INVALID not found' in str(exc_info.value)
+
+    def test_get_fee_rate_market_type_not_found(self):
+        """Test get_fee_rate with non-existent market type."""
+        # First, we need to add some test data to EXCHANGE_FEES
+        test_exchange = {
+            'spot': {
+                'vip_levels': {0: {'maker': 0.001, 'taker': 0.001}},
+                'discounts': {'platform_token_discount': 0.25, 'platform_token': 'TEST'}
+            }
+        }
+        calculator = FeeCalculator()
+        calculator.exchange_fees['TEST'] = test_exchange
+        
+        with pytest.raises(DependencyException) as exc_info:
+            calculator.get_fee_rate('TEST_000', 'TEST', 'invalid', True)
+        assert 'Market type invalid not found' in str(exc_info.value)
+
+    def test_get_fee_rate_vip_level_not_found(self):
+        """Test get_fee_rate with non-existent VIP level."""
+        test_exchange = {
+            'spot': {
+                'vip_levels': {0: {'maker': 0.001, 'taker': 0.001}},
+                'discounts': {'platform_token_discount': 0.25, 'platform_token': 'TEST'}
+            }
+        }
+        calculator = FeeCalculator()
+        calculator.exchange_fees['TEST'] = test_exchange
+        
+        # Should fallback to level 0 if VIP level not found
+        rate = calculator.get_fee_rate('TEST_000', 'TEST', 'spot', True)
+        assert rate == 0.001
+
+    def test_get_fee_rate_maker(self):
+        """Test get_fee_rate for maker order."""
+        test_exchange = {
+            'spot': {
+                'vip_levels': {
+                    0: {'maker': 0.001, 'taker': 0.001},
+                    1: {'maker': 0.0009, 'taker': 0.001}
+                },
+                'discounts': {
+                    'platform_token_discount': 0.25,
+                    'platform_token': 'TEST',
+                    'holding_discount': {}
+                }
+            }
+        }
+        calculator = FeeCalculator()
+        calculator.exchange_fees['TEST'] = test_exchange
+        
+        rate = calculator.get_fee_rate('TEST_000', 'TEST', 'spot', True)
+        assert rate == 0.001
+
+    def test_get_fee_rate_taker(self):
+        """Test get_fee_rate for taker order."""
+        test_exchange = {
+            'spot': {
+                'vip_levels': {
+                    0: {'maker': 0.001, 'taker': 0.001},
+                    1: {'maker': 0.0009, 'taker': 0.001}
+                },
+                'discounts': {
+                    'platform_token_discount': 0.25,
+                    'platform_token': 'TEST',
+                    'holding_discount': {}
+                }
+            }
+        }
+        calculator = FeeCalculator()
+        calculator.exchange_fees['TEST'] = test_exchange
+        
+        rate = calculator.get_fee_rate('TEST_000', 'TEST', 'spot', False)
+        assert rate == 0.001
+
+    def test_get_fee_rate_with_platform_token_discount(self):
+        """Test get_fee_rate with platform token discount."""
+        test_exchange = {
+            'spot': {
+                'vip_levels': {
+                    0: {'maker': 0.001, 'taker': 0.001}
+                },
+                'discounts': {
+                    'platform_token_discount': 0.25,
+                    'platform_token': 'TEST',
+                    'holding_discount': {}
+                }
+            }
+        }
+        calculator = FeeCalculator()
+        calculator.exchange_fees['TEST'] = test_exchange
+        
+        # Mock config to enable platform token discount
+        config = Mock(spec=ConfigAgent)
+        config.outer = MagicMock()
+        config.outer.sections.return_value = ['TEST_ACCOUNT']
+        calculator.config = config
+        
+        with patch.object(
+            calculator,
+            '_get_account_fee_config',
+            return_value={
+                'vip_level': 0,
+                'use_platform_token_discount': True,
+                'holding_discount': False
+            }
+        ):
+            rate = calculator.get_fee_rate('TEST_000', 'TEST', 'spot', True)
+            # 0.001 * (1 - 0.25) = 0.00075
+            assert rate == 0.00075
+
+    def test_get_fee_rate_with_holding_discount(self):
+        """Test get_fee_rate with holding discount."""
+        test_exchange = {
+            'spot': {
+                'vip_levels': {
+                    0: {'maker': 0.001, 'taker': 0.001}
+                },
+                'discounts': {
+                    'platform_token_discount': 0.25,
+                    'platform_token': 'TEST',
+                    'holding_discount': {'discount_rate': 0.1}
+                }
+            }
+        }
+        calculator = FeeCalculator()
+        calculator.exchange_fees['TEST'] = test_exchange
+        
+        config = Mock(spec=ConfigAgent)
+        config.outer = MagicMock()
+        config.outer.sections.return_value = ['TEST_ACCOUNT']
+        calculator.config = config
+        
+        with patch.object(
+            calculator,
+            '_get_account_fee_config',
+            return_value={
+                'vip_level': 0,
+                'use_platform_token_discount': False,
+                'holding_discount': True
+            }
+        ):
+            rate = calculator.get_fee_rate('TEST_000', 'TEST', 'spot', True)
+            # 0.001 * (1 - 0.1) = 0.0009
+            assert rate == 0.0009
+
+    def test_get_fee_rate_with_both_discounts(self):
+        """Test get_fee_rate with both platform token and holding discounts."""
+        test_exchange = {
+            'spot': {
+                'vip_levels': {
+                    0: {'maker': 0.001, 'taker': 0.001}
+                },
+                'discounts': {
+                    'platform_token_discount': 0.25,
+                    'platform_token': 'TEST',
+                    'holding_discount': {'discount_rate': 0.1}
+                }
+            }
+        }
+        calculator = FeeCalculator()
+        calculator.exchange_fees['TEST'] = test_exchange
+        
+        config = Mock(spec=ConfigAgent)
+        config.outer = MagicMock()
+        config.outer.sections.return_value = ['TEST_ACCOUNT']
+        calculator.config = config
+        
+        with patch.object(
+            calculator,
+            '_get_account_fee_config',
+            return_value={
+                'vip_level': 0,
+                'use_platform_token_discount': True,
+                'holding_discount': True
+            }
+        ):
+            rate = calculator.get_fee_rate('TEST_000', 'TEST', 'spot', True)
+            # 0.001 * (1 - 0.25) * (1 - 0.1) = 0.000675
+            assert rate == pytest.approx(0.000675)
+
+    def test_calculate_fee(self):
+        """Test calculate_fee method."""
+        test_exchange = {
+            'spot': {
+                'vip_levels': {
+                    0: {'maker': 0.001, 'taker': 0.001}
+                },
+                'discounts': {
+                    'platform_token_discount': 0.25,
+                    'platform_token': 'TEST',
+                    'holding_discount': {}
+                }
+            }
+        }
+        calculator = FeeCalculator()
+        calculator.exchange_fees['TEST'] = test_exchange
+        
+        fee = calculator.calculate_fee(
+            account_id='TEST_000',
+            exchange_id='TEST',
+            market_type='spot',
+            is_maker=True,
+            trade_amount=10000.0
+        )
+        # 10000 * 0.001 = 10
+        assert fee == 10.0
+
+    def test_calculate_fee_with_discount(self):
+        """Test calculate_fee with discount."""
+        test_exchange = {
+            'spot': {
+                'vip_levels': {
+                    0: {'maker': 0.001, 'taker': 0.001}
+                },
+                'discounts': {
+                    'platform_token_discount': 0.25,
+                    'platform_token': 'TEST',
+                    'holding_discount': {}
+                }
+            }
+        }
+        calculator = FeeCalculator()
+        calculator.exchange_fees['TEST'] = test_exchange
+        
+        config = Mock(spec=ConfigAgent)
+        config.outer = MagicMock()
+        config.outer.sections.return_value = ['TEST_ACCOUNT']
+        calculator.config = config
+        
+        with patch.object(
+            calculator,
+            '_get_account_fee_config',
+            return_value={
+                'vip_level': 0,
+                'use_platform_token_discount': True,
+                'holding_discount': False
+            }
+        ):
+            fee = calculator.calculate_fee(
+                account_id='TEST_000',
+                exchange_id='TEST',
+                market_type='spot',
+                is_maker=True,
+                trade_amount=10000.0
+            )
+            # 10000 * 0.001 * (1 - 0.25) = 7.5
+            assert fee == 7.5
+


### PR DESCRIPTION
1. 本次 PR 的目的（What & Why）  
   • 新增：统一的交易所手续费数据与费率解析器（FeeRateResolver），集中管理 VIP 费率/平台币折扣/持仓折扣，支持按配置读取。  
   • 修复：避免在业务侧散落硬编码费率，缺配置时可回退默认并记录日志。  
   • 优化：为手续费逻辑补充静态类型枚举与完整单元测试，提升可维护性与可测性。  
   • 原因：在套利等策略中需要准确、可配置的费率获取，降低后续接入成本。

2. 主要修改内容（Changes）  
   • 新增 `pytradekit/trading_setup/exchange_fees.py`：内含 EXCHANGE_FEES 全量费率表（Binance/HTX/OKX，现货+永续）与 `FeeRateResolver`，支持从 `{EXCHANGE}_ACCOUNT` section 读取 vip_level、平台币折扣、持仓折扣，缺省回退默认并打日志。  
   • 更新 `pytradekit/utils/static_types.py`：补充手续费相关枚举键（FeeStructureKey / FeeConfigAttribute 等）。  
   • 新增 `tests/test_exchange_fees.py`：覆盖费率解析的默认配置、配置读取、vip 等级缺失回退、平台币/持仓折扣组合场景。  
   • 微调 `trading_setup/websocket_restart_config.py`（格式/小变更）。

3. 是否影响以下关键功能？（Impact Check）  
   交易执行逻辑：否（新增模块，不改现有执行路径）  
   风控逻辑：否  
   交易池确定逻辑：否

4. 数据一致性  
   不涉及持久化数据结构变更；仅读取配置与静态费率表。

5. 测试（Testing）  
   本地测试：  
   • 单元测试：`tests/test_exchange_fees.py`（费率解析、折扣组合、配置缺省回退）  
   • 其余（模拟下单/回测/极端场景）：未覆盖（本次变更为配置与费率解析层）  
   部署测试：未执行（需上线前补充环境验证）。

6. 风险评估（Risk Assessment）  
   • 低：新增模块为只读配置与静态费率表，不改动现有执行流程。  
   • 风险点：配置缺失时回退默认费率，需确保上线环境配置完整；日志级别为 info，注意噪声。

7. 额外信息（Optional）  
   • 若后续需要与策略联动，可在调用侧统一接入 `FeeRateResolver` 并依据交易所/是否使用平台币折扣决定费率。

8. Reviewer Checklist（供 reviewer 使用）  
   • 费率表数据来源与数值是否符合官网档位  
   • 默认回退策略与日志级别是否合适  
   • 枚举与键名是否统一（static_types 中定义）  
   • 测试覆盖的折扣/等级场景是否满足预期