### PR TITLE
feat: Add API-based fee rate fetching with fallback mechanism

### DIFF
--- a/pytradekit/utils/dynamic_types.py
+++ b/pytradekit/utils/dynamic_types.py
@@ -891,6 +891,7 @@ class BinanceAuxiliary(Enum):
     url_swap_margin_type = '/fapi/v1/marginType'
     url_swap_open_interes_hist = '/futures/data/openInterestHist'
     url_alpha_exchange_info = "/bapi/defi/v1/public/wallet-direct/buw/wallet/cex/alpha/all/token/list"
+    url_commission_rate = '/fapi/v1/commissionRate'
     ws_aggtrade = "@aggTrade"
     ws_ticker = "!ticker@arr"
     ws_kline_interval = '@kline_15m'
@@ -939,6 +940,7 @@ class HuobiAuxiliary(Enum):
     url_orders = '/v1/order/history'
     url_trades = '/v1/order/matchresults'
     url_swap_balance = '/linear-swap-api/v1/swap_balance_valuation'
+    url_commission_rate = '/v2/reference/transact-fee-rate/get'
     ws_ping_sleep = 1800
     reconnection_time_sleep = 60 * 60 * 2
 
@@ -959,6 +961,7 @@ class OkexAuxiliary(Enum):
     url_transfer_history = '/api/v5/asset/bills-history'
     url_orders = '/api/v5/trade/orders-history'
     url_trades = '/api/v5/trade/fills-history'
+    url_commission_rate = '/api/v5/account/trade-fee'
     ws_orders = '/ws/v5/private'
     ws_ping_sleep = 1800
     reconnection_time_sleep = 60 * 60 * 2

--- a/pytradekit/utils/static_types.py
+++ b/pytradekit/utils/static_types.py
@@ -1053,18 +1053,20 @@ class ArbitragePoolsReportAttribute(Enum):
     close_time = auto()
     day = auto()
     report = auto()  # list[ArbitragePool]: 套利池列表，每个元素包含 coin、short_leg、long_legs 等信息
+    fee_rate = auto()  # Dict[str, Dict[str, float]]: 所有inst_code的手续费，格式为 {inst_code: {"maker": float, "taker": float}}
     other = auto()
 
 
 class ArbitragePoolsReport:
     __slots__ = [attr.name for attr in ArbitragePoolsReportAttribute]
 
-    def __init__(self, event_time_ms, open_time, close_time, day, report, other=None):
+    def __init__(self, event_time_ms, open_time, close_time, day, report, fee_rate=None, other=None):
         self.event_time_ms = event_time_ms
         self.open_time = open_time
         self.close_time = close_time
         self.day = day
         self.report = report
+        self.fee_rate = fee_rate if fee_rate is not None else {}
         self.other = other if other is not None else {}
 
     def to_dict(self):

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -19,3 +19,4 @@ httpx == 0.27.2
 snakeviz == 2.2.0
 freezegun == 1.5.2
 pynacl == 1.6.0
+pydantic == 1.10.8


### PR DESCRIPTION
## 1. 本次 PR 的目的（What & Why）

**新增：**
- 为 Binance、HTX、OKX 三个交易所的 REST 客户端添加获取手续费 API 的方法
- 扩展 `FeeRateResolver` 类，支持通过 API 获取实时手续费
- 在 `ArbitragePoolsReport` 中添加 `fee_rate` 字段，用于存储手续费信息
- 实现 API 优先、静态数据回退的容错机制

**优化：**
- 统一手续费返回格式，使用 `FeeStructureKey` 枚举值替代硬编码字符串
- 改进代码可维护性和类型一致性

**原因：**
- 各交易所已提供手续费 API 接口，可以获取账户级别的实时手续费
- 需要支持从 API 获取手续费，同时保留静态数据作为回退方案
- 为 cross_exchange_arbitrage 项目提供统一的手续费获取接口

## 2. 主要修改内容（Changes）

### 核心功能实现

1. **API 端点定义** (`utils/dynamic_types.py`)
   - `BinanceAuxiliary`: 添加 `url_commission_rate = '/fapi/v1/commissionRate'`
   - `HuobiAuxiliary`: 添加 `url_commission_rate = '/v2/reference/transact-fee-rate/get'`
   - `OkexAuxiliary`: 添加 `url_commission_rate = '/api/v5/account/trade-fee'`

2. **REST 客户端扩展**
   - `restful/binance_restful.py`: 添加 `get_commission_rate(symbol)` 方法
   - `restful/huobi_restful.py`: 添加 `get_commission_rate(symbol)` 方法
   - `restful/okex_restful.py`: 添加 `get_commission_rate(inst_type, inst_id)` 方法
   - 所有方法返回格式统一：`{FeeStructureKey.maker.name: float, FeeStructureKey.taker.name: float}`

3. **FeeRateResolver 扩展** (`trading_setup/exchange_fees.py`)
   - `_create_rest_client()`: 根据 exchange_id 和 market_type 创建 REST 客户端，支持从 config 获取 API 凭证
   - `get_fee_rate_from_api()`: 优先从 API 获取手续费，失败时自动回退到静态数据
   - 使用延迟导入避免依赖问题

4. **ArbitragePoolsReport 扩展** (`utils/static_types.py`)
   - 在 `ArbitragePoolsReportAttribute` 枚举中添加 `fee_rate` 字段
   - 在 `ArbitragePoolsReport` 类中添加 `fee_rate` 参数
   - 数据格式：`Dict[str, Dict[str, float]]`，例如 `{"BN_BTCUSDT_PERP": {"maker": 0.0002, "taker": 0.0004}}`

## 3. 是否影响以下关键功能？（Impact Check）

- **交易执行逻辑**：❌ 不影响
- **风控逻辑**：❌ 不影响  
- **交易池确定逻辑**：✅ 影响（提供手续费数据支持，但本身不改变交易池确定逻辑）

## 4. 数据一致性

- 手续费数据通过 API 获取，确保与交易所账户实际手续费一致
- API 失败时使用静态数据作为回退，保证数据可用性
- 返回格式统一使用 `FeeStructureKey` 枚举值，保持类型一致性
- 支持按 inst_code 和 market_type 精确获取手续费

## 5. 测试（Testing）

**本地测试：**
- ✅ 代码通过 linter 检查，无语法错误
- ✅ 使用 `FeeStructureKey` 枚举值，保持类型一致性
- ✅ 异常处理完善，API 调用失败时正确回退到静态数据
- ✅ 延迟导入 `get_account_api`，避免依赖链问题
- ⚠️ 需要在实际环境中测试 API 调用（需要有效的 API 凭证）

**单元测试：**
- ✅ `tests/test_exchange_fees.py` 包含完整的测试用例
- ✅ 测试覆盖 FeeRateResolver 的核心功能
- ✅ 测试 API 失败时的回退机制

## 6. 风险评估（Risk Assessment）

**低风险：**
- 新增功能，不影响现有交易逻辑
- API 调用失败时有完善的回退机制
- 使用延迟导入避免依赖问题
- 所有 REST 客户端方法都有异常处理

**注意事项：**
- 需要确保各交易所 API 凭证配置正确
- 遵守各交易所的 API 调用频率限制
- 首次运行时需要验证 API 返回的数据格式是否符合预期
- 不同交易所的 API 响应格式可能不同，需要适配

## 7. 额外信息（Optional）

- 支持 Binance、HTX、OKX 三个交易所的手续费获取
- 使用 `FeeStructureKey` 枚举值替代硬编码字符串，提高代码可维护性
- 实现延迟导入机制，避免模块加载时的依赖问题
- 为 cross_exchange_arbitrage 项目提供统一的手续费获取接口

## 8. Reviewer Checklist（供 reviewer 使用）

- [ ] 代码风格符合项目规范（PEP8、函数命名等）
- [ ] 异常处理完善，API 调用失败时能正确回退
- [ ] 使用 `FeeStructureKey` 枚举值，保持类型一致性
- [ ] API 端点定义正确，符合各交易所文档
- [ ] REST 客户端方法返回格式统一
- [ ] `fee_rate` 字段格式正确：`{inst_code: {"maker": float, "taker": float}}`
- [ ] 延迟导入机制正确，避免依赖问题
- [ ] 单元测试覆盖核心功能
- [ ] 需要验证 API 调用在实际环境中的表现

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add commission-rate API for Binance/HTX/OKX, integrate API-first fee resolution with static fallback, and store fees in arbitrage reports.
> 
> - **REST Clients**:
>   - Add `get_commission_rate(...)` to `pytradekit/restful/binance_restful.py`, `.../huobi_restful.py`, and `.../okex_restful.py` returning `{FeeStructureKey.maker.name, FeeStructureKey.taker.name}`.
>   - Define commission-rate endpoints in `pytradekit/utils/dynamic_types.py` (`BinanceAuxiliary.url_commission_rate`, `HuobiAuxiliary.url_commission_rate`, `OkexAuxiliary.url_commission_rate`).
> - **Fee Resolution** (`pytradekit/trading_setup/exchange_fees.py`):
>   - Implement `_create_rest_client(...)` to instantiate clients using config credentials.
>   - Implement `get_fee_rate_from_api(...)` with API-first retrieval and static `EXCHANGE_FEES` fallback; add symbol/instId conversions.
>   - Use `FeeConfigAttribute` uppercase keys consistently.
> - **Reporting** (`pytradekit/utils/static_types.py`):
>   - Extend `ArbitragePoolsReportAttribute` and `ArbitragePoolsReport` with `fee_rate` field and serialization support.
> - **Dependencies**:
>   - Add `pydantic==1.10.8` to `shared_requirements.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a1a01ca74b70b4f875952d850405161bb4cf329. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->