### PR TITLE
refactor: Unify inst_code format to use pair format (BASE-QUOTE)

### DIFF
--- a/pytradekit/trading_setup/inst_code_usage.py
+++ b/pytradekit/trading_setup/inst_code_usage.py
@@ -16,7 +16,7 @@ VENDOR_EXCHANGE = [ExchangeId.MCO.name, ExchangeId.EMO.name, ExchangeId.BUL.name
 
 class MmInstCode:
     STABLE_COINS = ['USDT', 'TUSD', 'USDC', ' USDD']
-    BN = ['SOLFDUSD_BN.SPOT']
+    BN = ['SOL-FDUSD_BN.SPOT']  # Updated to pair format (BASE-QUOTE)
     KC = []
     MCO = []
     BMT = []
@@ -172,49 +172,146 @@ def get_related_inst_code(exchange_id: str, inst_code_basic: DataFrame) -> DataF
 
 def convert_pair_to_inst_code(pair: str, exchange_id=ExchangeId.BN.name, types=InstCodeType.SPOT.name) -> str:
     """
-    btc_usdt --> BTCUSDT_BN.SPOT
+    Convert pair to inst_code.
+    
+    Args:
+        pair: Trading pair in format 'BTC-USDT' (hyphen-separated, uppercase)
+        exchange_id: Exchange ID (e.g., 'BN')
+        types: Instrument type (e.g., 'SPOT')
+    
+    Returns:
+        inst_code: Instrument code in format 'BTC-USDT_BN.SPOT'
+    
+    Example:
+        'BTC-USDT' -> 'BTC-USDT_BN.SPOT'
     """
-    parts = pair.split('_')
-    parts = [p.upper() for p in parts]
-    inst_code = f'{parts[0]}{parts[1]}_{exchange_id}.{types}'
+    pair_upper = pair.upper().replace('_', '-')
+    inst_code = f'{pair_upper}_{exchange_id}.{types}'
     return inst_code
 
 
 def convert_coin_to_inst_code(coin: str, exchange_id=ExchangeId.BN.name, types=InstCodeType.SPOT.name) -> str:
-    pair = f'{coin.upper()}USDT'
+    """
+    Convert coin to inst_code (assumes USDT as quote).
+    
+    Args:
+        coin: Base currency (e.g., 'BTC')
+        exchange_id: Exchange ID (e.g., 'BN')
+        types: Instrument type (e.g., 'SPOT')
+    
+    Returns:
+        inst_code: Instrument code in format 'BTC-USDT_BN.SPOT'
+    
+    Example:
+        'BTC' -> 'BTC-USDT_BN.SPOT'
+    """
+    pair = f'{coin.upper()}-USDT'
     inst_code = f'{pair}_{exchange_id}.{types}'
     return inst_code
 
 def convert_symbol_to_inst_code(symbol: str, exchange_id=ExchangeId.BN.name, types=InstCodeType.SPOT.name) -> str:
-    return f'{symbol}_{exchange_id}.{types}'
+    """
+    Convert symbol to inst_code.
+    
+    Args:
+        symbol: Trading symbol in format 'BTCUSDT' (no separator, uppercase)
+        exchange_id: Exchange ID (e.g., 'BN')
+        types: Instrument type (e.g., 'SPOT')
+    
+    Returns:
+        inst_code: Instrument code in format 'BTC-USDT_BN.SPOT'
+    
+    Example:
+        'BTCUSDT' -> 'BTC-USDT_BN.SPOT'
+    """
+    pair = convert_symbol_to_pair(symbol)
+    inst_code = f'{pair}_{exchange_id}.{types}'
+    return inst_code
 
 
 def convert_base_quote_to_inst_code(base: str, quote: str, exchange_id=ExchangeId.BN.name, types=InstCodeType.SPOT.name) -> str:
     """
-    btcusdt --> BTCUSDT_BN.SPOT
+    Convert base and quote to inst_code.
+    
+    Args:
+        base: Base currency (e.g., 'BTC')
+        quote: Quote currency (e.g., 'USDT')
+        exchange_id: Exchange ID (e.g., 'BN')
+        types: Instrument type (e.g., 'SPOT')
+    
+    Returns:
+        inst_code: Instrument code in format 'BTC-USDT_BN.SPOT'
+    
+    Example:
+        'BTC', 'USDT' -> 'BTC-USDT_BN.SPOT'
     """
     return base.upper() + "-" + quote.upper() + "_" + exchange_id + "." + types
 
 
+def convert_inst_code_to_pair(inst_code: str) -> str:
+    """
+    Convert inst_code to pair.
+    
+    Args:
+        inst_code: Instrument code in format 'BTC-USDT_BN.SPOT'
+    
+    Returns:
+        pair: Trading pair in format 'BTC-USDT' (hyphen-separated, uppercase)
+    
+    Example:
+        'BTC-USDT_BN.SPOT' -> 'BTC-USDT'
+    """
+    pair = inst_code.split('_')[0].upper()
+    return pair
+
+
 def convert_inst_code_to_symbol(inst_code: str) -> str:
     """
-    BTCUSDT_BN.SPOT -> btcusdt
+    Convert inst_code to symbol.
+    
+    Args:
+        inst_code: Instrument code in format 'BTC-USDT_BN.SPOT'
+    
+    Returns:
+        symbol: Trading symbol in format 'BTCUSDT' (no separator, uppercase)
+    
+    Example:
+        'BTC-USDT_BN.SPOT' -> 'BTCUSDT'
     """
-    symbol = inst_code.split('_')[0].replace('-', '').upper()
+    pair = inst_code.split('_')[0]
+    symbol = pair.replace('-', '').upper()
     return symbol
 
 
-def convert_pair_to_symbol(pair):
-    parts = pair.split('_')
-    return parts[0] + parts[1]
-
-
-def convert_symbol_to_base_quote_format(symbol: str) -> str:
+def convert_pair_to_symbol(pair: str) -> str:
     """
-    Normalize symbol to BASE-QUOTE format (e.g., BTCUSDT -> BTC-USDT).
+    Convert pair to symbol.
+    
+    Args:
+        pair: Trading pair in format 'BTC-USDT' (hyphen-separated, uppercase)
+    
+    Returns:
+        symbol: Trading symbol in format 'BTCUSDT' (no separator, uppercase)
+    
+    Example:
+        'BTC-USDT' -> 'BTCUSDT'
+    """
+    symbol = pair.replace('-', '').replace('_', '').upper()
+    return symbol
 
-    This helper is shared by projects that want to align inst_code reporting
-    across exchanges (e.g., BTC-USDT_BN.SPOT / BTC-USDT_OKX.SPOT).
+
+def convert_symbol_to_pair(symbol: str) -> str:
+    """
+    Convert symbol to pair.
+    
+    Args:
+        symbol: Trading symbol in format 'BTCUSDT' (no separator, uppercase)
+    
+    Returns:
+        pair: Trading pair in format 'BTC-USDT' (hyphen-separated, uppercase)
+    
+    Example:
+        'BTCUSDT' -> 'BTC-USDT'
     """
     symbol = symbol.upper().replace("-", "")
 
@@ -233,19 +330,18 @@ def convert_symbol_to_base_quote_format(symbol: str) -> str:
 
 def extract_base_from_inst_code(inst_code: str) -> str:
     """
-    从 inst_code 提取基础货币（base currency）
-    
-    例如：BTC-USDT_BN.PERP -> BTC
+    Extract base currency from inst_code.
     
     Args:
-        inst_code: 交易对代码，如 "BTC-USDT_BN.PERP"
+        inst_code: Instrument code in format 'BTC-USDT_BN.PERP'
     
     Returns:
-        str: 基础货币，如 "BTC"
+        str: Base currency, e.g., 'BTC'
+    
+    Example:
+        'BTC-USDT_BN.PERP' -> 'BTC'
     """
-    symbol = convert_inst_code_to_symbol(inst_code)
-    base_quote = convert_symbol_to_base_quote_format(symbol)
-    # base_quote 格式为 "BTC-USDT"，提取 base
-    if "-" in base_quote:
-        return base_quote.split("-")[0]
-    return base_quote
+    pair = convert_inst_code_to_pair(inst_code)
+    if "-" in pair:
+        return pair.split("-")[0]
+    return pair

--- a/pytradekit/utils/tools.py
+++ b/pytradekit/utils/tools.py
@@ -40,40 +40,17 @@ line_profiler = optional_import("line_profiler")
 memory_profiler = optional_import("memory_profiler")
 
 
-def convert_pair_to_inst_code(pair: str, exchange_id=ExchangeId.BN.name, types=InstCodeType.SPOT.name) -> str:
-    """
-    trx_usdt --> TRXUSDT_BN.SPOT
-    """
-    parts = pair.split('_')
-    parts = [p.upper() for p in parts]
-    inst_code = f'{parts[0]}-{parts[1]}_{exchange_id}.{types}'
-    return inst_code
-
-
-def convert_coin_to_inst_code(coin: str, exchange_id=ExchangeId.BN.name, types=InstCodeType.SPOT.name) -> str:
-    pair = f'{coin.upper()}-USDT'
-    inst_code = f'{pair}_{exchange_id}.{types}'
-    return inst_code
-
-
-def convert_base_quote_to_inst_code(base: str, quote: str, exchange_id=ExchangeId.BN.name, types=InstCodeType.SPOT.name) -> str:
-    """
-    trxusdt --> TRXUSDT_BN.SPOT
-    """
-    return base.upper() + "-" + quote.upper() + "_" + exchange_id + "." + types
-
-
-def convert_inst_code_to_pair(inst_code: str) -> str:
-    """
-    TRX-USDT_BN.SPOT -> trx-usdt
-    """
-    symbol = inst_code.split('_')[0].upper()
-    return symbol
-
-
-def convert_pair_to_symbol(pair):
-    parts = pair.split('_')
-    return parts[0] + parts[1]
+# Import conversion functions from inst_code_usage to avoid duplication
+from pytradekit.trading_setup.inst_code_usage import (
+    convert_pair_to_inst_code,
+    convert_coin_to_inst_code,
+    convert_base_quote_to_inst_code,
+    convert_inst_code_to_pair,
+    convert_pair_to_symbol,
+    convert_symbol_to_pair,
+    convert_symbol_to_inst_code,
+    convert_inst_code_to_symbol,
+)
 
 
 def synchronized(func):

--- a/tests/test_custom_types.py
+++ b/tests/test_custom_types.py
@@ -42,7 +42,7 @@ def test_from_string_quote_only():
 
 def test_trading_order_volume_calculation():
     # Create an instance of InstCode as required by TradingOrder
-    inst_code = InstCode(symbol='BNBTUSD', exchange_id='BN', category='SPOT')
+    inst_code = InstCode(pair='BNB-TUSD', exchange_id='BN', category='SPOT')
     a_error = None
 
     # Create the TradingOrder object
@@ -66,7 +66,7 @@ def test_trading_order_volume_calculation():
 
 def test_cancel_order_delay_calculation():
     # Create an instance of CancelOrder with timestamps
-    inst_code = InstCode(symbol='BNBTUSD', exchange_id='BN', category='SPOT')
+    inst_code = InstCode(pair='BNB-TUSD', exchange_id='BN', category='SPOT')
     client_order_id = ClientOrderId(client_order_id='1231234', strategy_id='jwj_kline')
     order = CancelOrder(
         inst_code=inst_code,

--- a/tests/test_inst_code_usage.py
+++ b/tests/test_inst_code_usage.py
@@ -148,8 +148,8 @@ def test_get_pair_key_mm_target_default():
 def sample_inst_code_basic():
     data = {
         InstcodeBasicAttribute.inst_code.name: [
-            'TRXUSDT_BN.SPOT', 'TUSDUSDT_BN.SPOT', 'TRXTUSD_BN.SPOT',
-            'BTCUSDT_BN.SPOT', 'ETHUSDT_BN.SPOT', 'XRPUSDT_BN.SPOT', 'XRPTUSD_BN.SPOT',
+            'TRX-USDT_BN.SPOT', 'TUSD-USDT_BN.SPOT', 'TRX-TUSD_BN.SPOT',
+            'BTC-USDT_BN.SPOT', 'ETH-USDT_BN.SPOT', 'XRP-USDT_BN.SPOT', 'XRP-TUSD_BN.SPOT',
         ],
         InstcodeBasicAttribute.base.name: ['TRX', 'TUSD', 'TRX', 'BTC', 'ETH', 'XRP', 'XRP'],
         InstcodeBasicAttribute.quote.name: ['USDT', 'USDT', 'TUSD', 'USDT', 'USDT', 'USDT', 'TUSD']
@@ -162,28 +162,28 @@ def test_get_related_inst_code_normal(mocker, sample_inst_code_basic):
     # 返回多个做市交易对，以便找到更多相关交易对
     mocker.patch(
         'pytradekit.trading_setup.inst_code_usage.fetch_mm_inst_code',
-        return_value=['TRXTUSD_BN.SPOT', 'TRXUSDT_BN.SPOT', 'TUSDUSDT_BN.SPOT', 'XRPTUSD_BN.SPOT']
+        return_value=['TRX-TUSD_BN.SPOT', 'TRX-USDT_BN.SPOT', 'TUSD-USDT_BN.SPOT', 'XRP-TUSD_BN.SPOT']
     )
     result = get_related_inst_code('BN', sample_inst_code_basic)
 
     # 验证结果包含做市交易对和相关交易对
-    # 做市交易对: TRXTUSD, TRXUSDT, TUSDUSDT, XRPTUSD
+    # 做市交易对: TRX-TUSD, TRX-USDT, TUSD-USDT, XRP-TUSD
     # all_tokens = {TRX, TUSD, USDT, XRP}
     # 相关交易对: base 和 quote 都在 all_tokens 中的交易对
-    # 应该包含: TRXTUSD, TRXUSDT, TUSDUSDT, XRPTUSD, XRPUSDT
+    # 应该包含: TRX-TUSD, TRX-USDT, TUSD-USDT, XRP-TUSD, XRP-USDT
     assert len(result) >= 5  # 至少包含做市交易对和相关交易对
-    assert 'TRXTUSD_BN.SPOT' in result[InstcodeBasicAttribute.inst_code.name].values
-    assert 'TRXUSDT_BN.SPOT' in result[InstcodeBasicAttribute.inst_code.name].values
-    assert 'TUSDUSDT_BN.SPOT' in result[InstcodeBasicAttribute.inst_code.name].values
-    assert 'XRPTUSD_BN.SPOT' in result[InstcodeBasicAttribute.inst_code.name].values
-    assert 'XRPUSDT_BN.SPOT' in result[InstcodeBasicAttribute.inst_code.name].values
+    assert 'TRX-TUSD_BN.SPOT' in result[InstcodeBasicAttribute.inst_code.name].values
+    assert 'TRX-USDT_BN.SPOT' in result[InstcodeBasicAttribute.inst_code.name].values
+    assert 'TUSD-USDT_BN.SPOT' in result[InstcodeBasicAttribute.inst_code.name].values
+    assert 'XRP-TUSD_BN.SPOT' in result[InstcodeBasicAttribute.inst_code.name].values
+    assert 'XRP-USDT_BN.SPOT' in result[InstcodeBasicAttribute.inst_code.name].values
 
 
 def test_get_related_inst_code_empty(mocker, sample_inst_code_basic):
     # 模拟fetch_mm_inst_code返回值
     mocker.patch(
         'pytradekit.trading_setup.inst_code_usage.fetch_mm_inst_code',
-        return_value=['NONEXIST_BN.SPOT']
+        return_value=['NON-EXIST_BN.SPOT']
     )
 
     result = get_related_inst_code('BN', sample_inst_code_basic)
@@ -197,11 +197,11 @@ def test_get_related_inst_code_no_related(mocker, sample_inst_code_basic):
     # 模拟fetch_mm_inst_code返回值
     mocker.patch(
         'pytradekit.trading_setup.inst_code_usage.fetch_mm_inst_code',
-        return_value=['BTCUSDT_BN.SPOT']
+        return_value=['BTC-USDT_BN.SPOT']
     )
 
     result = get_related_inst_code('BN', sample_inst_code_basic)
 
     # 验证只返回做市交易对
     assert len(result) == 1
-    assert 'BTCUSDT_BN.SPOT' in result[InstcodeBasicAttribute.inst_code.name].values
+    assert 'BTC-USDT_BN.SPOT' in result[InstcodeBasicAttribute.inst_code.name].values


### PR DESCRIPTION
## 1. 本次 PR 的目的（What & Why）

**优化：**
- 统一 inst_code、pair、symbol 的格式规范和转换函数
- inst_code 格式从 symbol 格式（BTCUSDT_BN.SPOT）改为 pair 格式（BTC-USDT_BN.SPOT）
- pair 格式统一为连字符分隔的大写格式（BTC-USDT）
- symbol 格式保持不变（BTCUSDT，无分隔符）
- 删除冗余函数 `convert_symbol_to_base_quote_format`，统一使用 `convert_symbol_to_pair`

**原因：**
- 统一命名规范，提高代码可维护性和一致性
- inst_code 使用 pair 格式更清晰，便于识别 base 和 quote
- 减少代码重复，统一转换函数命名
- 与 cross_exchange_arbitrage 项目保持一致，确保两个项目的代码规范统一

## 2. 主要修改内容（Changes）

### 核心修改

1. **pytradekit/trading_setup/inst_code_usage.py**
   - 更新 `convert_pair_to_inst_code`：支持 pair 格式（BTC-USDT），生成 inst_code 为 BTC-USDT_BN.SPOT
   - 更新 `convert_coin_to_inst_code`：生成 pair 格式（BTC-USDT）
   - 更新 `convert_symbol_to_inst_code`：内部调用 `convert_symbol_to_pair` 进行转换
   - 更新 `convert_inst_code_to_pair`：从 inst_code 提取 pair（BTC-USDT_BN.SPOT -> BTC-USDT）
   - 更新 `convert_inst_code_to_symbol`：从 inst_code 提取 symbol（BTC-USDT_BN.SPOT -> BTCUSDT）
   - 新增 `convert_pair_to_symbol`：pair 转 symbol（BTC-USDT -> BTCUSDT）
   - 更新 `convert_symbol_to_pair`：实现 symbol 转 pair 的逻辑（原 `convert_symbol_to_base_quote_format` 的逻辑）
   - **删除** `convert_symbol_to_base_quote_format` 函数
   - 更新 `MmInstCode.BN`：使用 pair 格式（SOL-FDUSD_BN.SPOT）

2. **pytradekit/utils/custom_types.py**
   - 更新 `InstCode` 类：使用 `pair` 字段替代 `symbol` 字段
   - 更新 `from_string` 方法：支持旧格式（BTCUSDT_BN.SPOT）和新格式（BTC-USDT_BN.SPOT），自动转换
   - 更新 `get_report_symbol` 方法：从 pair 生成 symbol

3. **pytradekit/utils/tools.py**
   - 更新 `convert_pair_to_inst_code`：使用连字符格式（BASE-QUOTE）
   - 更新 `convert_coin_to_inst_code`：使用连字符格式（BASE-QUOTE）
   - 简化代码，移除重复逻辑

4. **pytradekit/trading_setup/exchange_fees.py**
   - 更新 `get_fee_rate_from_api` 方法：使用 `convert_inst_code_to_symbol` 和 `convert_symbol_to_pair` 进行格式转换
   - 确保 API 调用时使用正确的 symbol 格式

5. **tests/test_custom_types.py**
   - 更新测试用例：使用 pair 格式构造 `InstCode` 对象
   - 确保测试用例符合新的格式规范

6. **tests/test_inst_code_usage.py**
   - 更新所有测试用例：使用新的 pair 格式（BTC-USDT_BN.SPOT）
   - 更新 `MmInstCode.BN` 测试数据
   - 验证所有转换函数的正确性

## 3. 是否影响以下关键功能？（Impact Check）

- **交易执行逻辑**：✅ 影响（inst_code 格式改变，但通过向后兼容处理）
- **风控逻辑**：❌ 不影响
- **交易池确定逻辑**：✅ 影响（inst_code 格式改变，但功能逻辑不变）

**向后兼容性：**
- `InstCode.from_string` 方法支持旧格式（BTCUSDT_BN.SPOT）和新格式（BTC-USDT_BN.SPOT）
- 自动检测并转换旧格式到新格式

## 4. 数据一致性

- inst_code 格式统一为 pair 格式（BTC-USDT_BN.SPOT）
- 与 cross_exchange_arbitrage 项目保持一致
- 所有转换函数统一命名和实现
- 删除冗余函数，减少代码重复

## 5. 测试（Testing）

**本地测试：**
- ✅ 代码通过 linter 检查，无语法错误
- ✅ 所有转换函数已测试验证正常工作
- ✅ 测试用例已更新为新格式
- ✅ `InstCode.from_string` 向后兼容性已验证
- ⚠️ 需要验证与 cross_exchange_arbitrage 的兼容性（cross_exchange_arbitrage 的对应 PR 需要同时合并）

**单元测试（相关 case）：**
- `test_convert_pair_to_inst_code`：验证 pair 转 inst_code
- `test_convert_inst_code_to_pair`：验证 inst_code 转 pair
- `test_convert_inst_code_to_symbol`：验证 inst_code 转 symbol
- `test_convert_pair_to_symbol`：验证 pair 转 symbol
- `test_convert_symbol_to_pair`：验证 symbol 转 pair
- `test_convert_symbol_to_inst_code`：验证 symbol 转 inst_code
- `test_custom_types`：验证 `InstCode` 类的 pair 字段和向后兼容性

**部署测试（如有）：**
- ⏳ 待 Dev 环境验证
- ⏳ 待验证所有使用 inst_code 的功能正常工作

## 6. 风险评估（Risk Assessment）

**中等风险：**
- inst_code 格式改变可能影响现有代码和数据的读取
- 需要确保与 cross_exchange_arbitrage 的更改同步合并
- 虽然提供了向后兼容性，但仍需验证所有使用场景

**注意事项：**
- 此 PR 需要与 cross_exchange_arbitrage 的对应 PR 同时合并
- `InstCode.from_string` 提供了向后兼容性，但建议逐步迁移到新格式
- 建议在合并前进行全面的集成测试

## 7. 额外信息（Optional）

- 此重构是统一命名规范的一部分，与 cross_exchange_arbitrage 项目同步进行
- 所有转换函数已统一命名和实现，代码更加清晰和一致
- 删除了 `convert_symbol_to_base_quote_format`，统一使用 `convert_symbol_to_pair`
- 函数文档已更新，包含详细的参数说明和示例

## 8. Reviewer Checklist（供 reviewer 使用）

- [ ] 代码风格符合项目规范（PEP8）
- [ ] 所有转换函数已更新并测试通过
- [ ] inst_code 格式统一为 pair 格式
- [ ] 向后兼容性已验证
- [ ] 测试用例已更新并通过
- [ ] 与 cross_exchange_arbitrage 的更改保持一致
- [ ] 函数文档完整清晰
- [ ] 确认是否需要更新其他依赖项目