### PR TITLE
fix: improve websocket reconnection mechanism to prevent process crash

### DIFF
--- a/pytradekit/gateway/websocket/base_ws_manager.py
+++ b/pytradekit/gateway/websocket/base_ws_manager.py
@@ -130,15 +130,16 @@ class BaseWebsocketManager:
                 try:
                     f(ws, *args, **kwargs)
                 except Exception as e:
-                    raise ExchangeException(f'Error running websocket callback: {f.__name__}') from e
+                    self.logger.debug(f"error in websocket callback {f.__name__}: {e}")
+                    self.reconnect()
 
         return wrapped_f
 
     def _run_websocket(self, ws):
         try:
-            ws.run_forever(ping_interval=self._ping_interval)  # , ping_payload='Hello Server!')
+            ws.run_forever(ping_interval=self._ping_interval)
         except Exception as e:
-            raise ExchangeException('Unexpected error while running websocket') from e
+            self.logger.debug(f"websocket run_forever error: {e}")
         finally:
             self.reconnect()
 

--- a/pytradekit/ws/binance_ws.py
+++ b/pytradekit/ws/binance_ws.py
@@ -150,7 +150,7 @@ class BinanceWsManager(WsManager):
         for symbol in symbols:
             params.append(f'{symbol.lower()}{BinanceAuxiliary.ws_book_ticker.value}')
         self.start_subscribe(params)
-        self._ping(BinanceAuxiliary.ws_ping_sleep.value)
+        self._ping(BinanceAuxiliary.ws_ping_sleep.value, is_listen_key=False)
 
     def start_swap_lastprice_stream(self, symbols):
         params = []

--- a/pytradekit/ws/okex_ws.py
+++ b/pytradekit/ws/okex_ws.py
@@ -59,7 +59,9 @@ class OkexWsManager(WsManager):
             try:
                 self.send("ping")
             except Exception as e:
-                self.logger.error(f"Okex heartbeat error: {e}")
+                self.logger.debug(f"okex heartbeat error: {e}, triggering reconnect")
+                self.reconnect()
+                break
 
     def _login(self):
         nonce = str(get_timestamp_s())


### PR DESCRIPTION
## 1. 本次 PR 的目的（What & Why）

### 修复：
- WebSocket 回调异常导致进程退出的问题
- WebSocket 连接断开后无法自动重连的问题
- Binance bookticker stream 错误调用 listen_key API 的问题
- OKX 心跳失败后不触发重连的问题

### 原因：
在 `realtime_compute_premium` 运行过程中，发现 websocket 子进程经常变成僵尸进程 (defunct)。分析发现：
1. `_wrap_callback` 中的异常会被重新抛出，导致进程崩溃
2. `_run_websocket` 中 `run_forever` 的异常会被重新抛出
3. OKX 心跳失败只打印日志，不触发重连

## 2. 主要修改内容（Changes）

| 文件 | 修改内容 |
|------|----------|
| `base_ws_manager.py` | `_wrap_callback`: 捕获异常后触发重连，不再抛出异常 |
| `base_ws_manager.py` | `_run_websocket`: 捕获异常后记录日志，不再抛出异常 |
| `binance_ws.py` | `start_bookticker_stream`: 添加 `is_listen_key=False` 参数 |
| `okex_ws.py` | `_ping`: 心跳失败时触发重连并退出循环 |

## 3. 是否影响以下关键功能？（Impact Check）

| 功能 | 影响 |
|------|------|
| 交易执行逻辑 | ❌ 无影响 |
| 风控逻辑 | ❌ 无影响 |
| 交易池确定逻辑 | ❌ 无影响 |

## 4. 数据一致性

无数据变更，仅修改 WebSocket 连接管理逻辑。

## 5. 测试（Testing）

### 本地测试：
- [x] 代码审查通过
- [x] 异常场景分析：确认异常不会导致进程退出

### 部署测试：
- [ ] Dev 环境跑通
- [ ] 日志正常，无 error

## 6. 风险评估（Risk Assessment）

| 风险 | 等级 | 说明 |
|------|------|------|
| 重连逻辑变更 | 低 | 重连触发逻辑更积极，可能增加重连频率 |

## 7. 额外信息（Optional）

此 PR 与 `cross_exchange_arbitrage` 的 #73 PR 配合使用，共同解决僵尸进程问题。

## 8. Reviewer Checklist（供 reviewer 使用）

- [ ] 代码逻辑正确
- [ ] 异常处理合理
- [ ] 日志级别正确（使用 debug）
- [ ] 无副作用