### PR TITLE
feat: 新增多交易所 WebSocket 交易推送支持

### DIFF
--- a/pytradekit/gateway/websocket/base_ws_manager.py
+++ b/pytradekit/gateway/websocket/base_ws_manager.py
@@ -26,13 +26,13 @@ class BaseWebsocketManager:
     def _on_message(self, ws, message, *args, **kwargs):
         raise NotImplementedError()
 
-    def _on_open(self):
+    def _on_open(self, ws, *args, **kwargs):
         pass
 
-    def _on_close(self):
+    def _on_close(self, ws, *args, **kwargs):
         self.reconnect()
 
-    def _on_error(self, ws, error):
+    def _on_error(self, ws, error, *args, **kwargs):
         self.logger.debug(f"ws :{ws} connection error: {error}")
         self.reconnect()
 
@@ -128,7 +128,6 @@ class BaseWebsocketManager:
         def wrapped_f(ws, *args, **kwargs):
             if ws is self.ws:
                 try:
-                    print("_wrap_callback: ", f, ws, args, kwargs)
                     f(ws, *args, **kwargs)
                 except Exception as e:
                     self.logger.debug(f"error in websocket callback {f.__name__}: {e}")

--- a/pytradekit/gateway/websocket/base_ws_manager.py
+++ b/pytradekit/gateway/websocket/base_ws_manager.py
@@ -26,7 +26,8 @@ class BaseWebsocketManager:
     def _on_message(self, ws, message, *args, **kwargs):
         raise NotImplementedError()
 
-    def _on_open(self):
+    def _on_open(self, **kwargs):
+        print(f'_on_open: {kwargs}')
         pass
 
     def _on_close(self):

--- a/pytradekit/gateway/websocket/base_ws_manager.py
+++ b/pytradekit/gateway/websocket/base_ws_manager.py
@@ -26,8 +26,7 @@ class BaseWebsocketManager:
     def _on_message(self, ws, message, *args, **kwargs):
         raise NotImplementedError()
 
-    def _on_open(self, **kwargs):
-        print(f'_on_open: {kwargs}')
+    def _on_open(self):
         pass
 
     def _on_close(self):
@@ -129,6 +128,7 @@ class BaseWebsocketManager:
         def wrapped_f(ws, *args, **kwargs):
             if ws is self.ws:
                 try:
+                    print("_wrap_callback: ", f, ws, args, kwargs)
                     f(ws, *args, **kwargs)
                 except Exception as e:
                     self.logger.debug(f"error in websocket callback {f.__name__}: {e}")

--- a/pytradekit/utils/dynamic_types.py
+++ b/pytradekit/utils/dynamic_types.py
@@ -949,7 +949,7 @@ class BitfinexAuxiliary(Enum):
 
 class HuobiAuxiliary(Enum):
     url = 'https://api.huobi.pro'
-    url_ws = 'wss://api.huobi.pro/ws'
+    url_ws = 'wss://api.huobi.pro/ws/v2'
     url_exchange = '/v2/settings/common/symbols'
     url_ticker = '/market/tickers'
     swap_url = 'https://api.hbdm.com'
@@ -971,7 +971,7 @@ class HuobiAuxiliary(Enum):
 
 class OkexAuxiliary(Enum):
     url = 'https://www.okx.com'
-    url_ws = 'wss://ws.okx.com:8443/ws/v5/public'
+    url_ws = 'wss://ws.okx.com:8443/ws/v5/private'
     swap_url = 'https://www.okx.com'
     url_swap_position = '/api/v5/account/positions'
     url_swap_interest = '/api/v5/account/interest-accrued'

--- a/pytradekit/utils/dynamic_types.py
+++ b/pytradekit/utils/dynamic_types.py
@@ -145,6 +145,7 @@ class BinanceWebSocket(Enum):
     trade_price = "L"
     trade_volume = "l"
     traded_time_ms = "T"
+    trade_filled = "FILLED"
     trade_id = "t"
     fee = "n"
     working_time = "W"
@@ -172,6 +173,7 @@ class BinanceWebSocket(Enum):
     orderbook_bids = 'b'
     orderbook_asks = 'a'
     BUY = 'BUY'
+    order_sell = 'SELL'
     lastUpdateId = 'lastUpdateId'
     balance_ws_time = 'E'
     balance_ws_coin = 'a'
@@ -272,6 +274,7 @@ class BitfinexWebSocket(Enum):
 class HuobiWebSocket(Enum):
     order_type = 'type'
     order_buy = 'buy'
+    order_sell = 'sell'
     order_client_order_id = 'clientOrderId'
     order_type_limit = 'limit'
     account_id = 'account_id'
@@ -299,6 +302,7 @@ class HuobiWebSocket(Enum):
     orderbook_bid = 'bid'
     orderbook_ask = 'ask'
     orderbook_time = 'quoteTime'
+    trade_filled = 'filled'
 
 
 class OkexWebSocket(Enum):
@@ -310,6 +314,7 @@ class OkexWebSocket(Enum):
     strategy_id = 'strategy_id'
     order_side = 'side'
     order_buy = 'buy'
+    order_sell = 'sell'
     order_type = 'ordType'
     order_limit = 'limit'
     order_price = 'px'
@@ -326,6 +331,7 @@ class OkexWebSocket(Enum):
     trade_volume = 'fillSz'
     trade_price = 'fillPx'
     traded_time_ms = 'fillTime'
+    trade_filled = 'filled'
     trade_id = 'tradeId'
     trade_fee = 'fee'
     trade_fee_coin = 'feeCcy'

--- a/pytradekit/ws/binance_ws.py
+++ b/pytradekit/ws/binance_ws.py
@@ -231,6 +231,7 @@ class BinanceWsManager(WsManager):
             if BinanceAuxiliary.ws_ping.value in msg:
                 self._pong()
             else:
+                print(msg)
                 if self.verify_spot_bookticker_duplicate(msg):
                     self._queue.put_nowait(msg)
                     return

--- a/pytradekit/ws/binance_ws.py
+++ b/pytradekit/ws/binance_ws.py
@@ -227,11 +227,11 @@ class BinanceWsManager(WsManager):
 
     def _on_message(self, _ws, message):
         msg = json.loads(message)
+        print(msg, "===============")
         try:
             if BinanceAuxiliary.ws_ping.value in msg:
                 self._pong()
             else:
-                print(msg)
                 if self.verify_spot_bookticker_duplicate(msg):
                     self._queue.put_nowait(msg)
                     return

--- a/pytradekit/ws/binance_ws.py
+++ b/pytradekit/ws/binance_ws.py
@@ -230,8 +230,8 @@ class BinanceWsManager(WsManager):
 
     def _on_message(self, _ws, message):
         msg = json.loads(message)
-        print(msg, "===============")
         try:
+            print(f"binance : {msg}")
             if BinanceAuxiliary.ws_ping.value in msg:
                 self._pong()
             else:

--- a/pytradekit/ws/binance_ws.py
+++ b/pytradekit/ws/binance_ws.py
@@ -103,7 +103,7 @@ class BinanceWsManager(WsManager):
             params = [self._listen_key['SPOT']]
             if self._send_params:
                 params += self._send_params
-            self.logger.debug(f"subscribe: {params}")
+            self.logger.debug(f"subscribe: {params}, url: {self._url}")
             self.start_subscribe(params)
             self._ping(BinanceAuxiliary.ws_ping_sleep.value,
                        reconnection_time=BinanceAuxiliary.reconnection_time_sleep.value)

--- a/pytradekit/ws/binance_ws.py
+++ b/pytradekit/ws/binance_ws.py
@@ -235,15 +235,16 @@ class BinanceWsManager(WsManager):
             if BinanceAuxiliary.ws_ping.value in msg:
                 self._pong()
             else:
-                if self.verify_spot_bookticker_duplicate(msg):
-                    self._queue.put_nowait(msg)
-                    return
-                if self.verify_spot_order_trade(msg):
-                    self._queue.put_nowait(msg)
-                    return
-                if self.verify_perp_order_trade(msg):
-                    self._queue.put_nowait(msg)
-                    return
+                # if self.verify_spot_order_trade(msg):
+                #     self._queue.put_nowait(msg)
+                #     return
+                # if self.verify_perp_order_trade(msg):
+                #     self._queue.put_nowait(msg)
+                #     return
+                # if self.verify_spot_bookticker_duplicate(msg):
+                #     self._queue.put_nowait(msg)
+                #     return
+                self._queue.put_nowait(msg)
         except Exception as e:
             self.logger.exception(e)
             self.logger.debug(f"binance message error {msg}")

--- a/pytradekit/ws/binance_ws.py
+++ b/pytradekit/ws/binance_ws.py
@@ -198,7 +198,7 @@ class BinanceWsManager(WsManager):
                 self.start_end_time_dict['start_time'] = times
 
     def verify_spot_bookticker_duplicate(self, msg):
-        if BinanceWebSocket.order_book_update_id.value not in msg:
+        if BinanceWebSocket.order_book_update_id.value not in msg or BinanceWebSocket.symbol.value not in msg or BinanceWebSocket.orderbook_asks.value not in msg or BinanceWebSocket.orderbook_bids.value not in msg:
             return False
         if msg[BinanceWebSocket.symbol.value] not in self.verify_bookticker_duplicate:
             self.verify_bookticker_duplicate[msg[BinanceWebSocket.symbol.value]] = msg[

--- a/pytradekit/ws/binance_ws.py
+++ b/pytradekit/ws/binance_ws.py
@@ -198,7 +198,7 @@ class BinanceWsManager(WsManager):
                 self.start_end_time_dict['start_time'] = times
 
     def verify_spot_bookticker_duplicate(self, msg):
-        if BinanceWebSocket.symbol.value not in msg:
+        if BinanceWebSocket.order_book_update_id.value not in msg:
             return False
         if msg[BinanceWebSocket.symbol.value] not in self.verify_bookticker_duplicate:
             self.verify_bookticker_duplicate[msg[BinanceWebSocket.symbol.value]] = msg[
@@ -217,13 +217,13 @@ class BinanceWsManager(WsManager):
         return True
 
     def verify_spot_order_trade(self, msg):
-        if BinanceWebSocket.event_type.value in msg and msg[BinanceWebSocket.event_type.value] in msg and msg[
+        if BinanceWebSocket.event_type.value in msg and msg[
             BinanceWebSocket.event_type.value] == BinanceWebSocket.execution_report.value:
             return True
         return False
 
     def verify_perp_order_trade(self, msg):
-        if BinanceWebSocket.event_type.value in msg and msg[BinanceWebSocket.event_type.value] in msg and msg[
+        if BinanceWebSocket.event_type.value in msg and msg[
             BinanceWebSocket.event_type.value] == BinanceWebSocket.perp_order_trade.value:
             return True
         return False
@@ -235,16 +235,15 @@ class BinanceWsManager(WsManager):
             if BinanceAuxiliary.ws_ping.value in msg:
                 self._pong()
             else:
-                # if self.verify_spot_order_trade(msg):
-                #     self._queue.put_nowait(msg)
-                #     return
-                # if self.verify_perp_order_trade(msg):
-                #     self._queue.put_nowait(msg)
-                #     return
-                # if self.verify_spot_bookticker_duplicate(msg):
-                #     self._queue.put_nowait(msg)
-                #     return
-                self._queue.put_nowait(msg)
+                if self.verify_perp_order_trade(msg):
+                    self._queue.put_nowait(msg)
+                    return
+                if self.verify_spot_order_trade(msg):
+                    self._queue.put_nowait(msg)
+                    return
+                if self.verify_spot_bookticker_duplicate(msg):
+                    self._queue.put_nowait(msg)
+                    return
         except Exception as e:
             self.logger.exception(e)
             self.logger.debug(f"binance message error {msg}")

--- a/pytradekit/ws/binance_ws.py
+++ b/pytradekit/ws/binance_ws.py
@@ -30,7 +30,10 @@ class BinanceWsManager(WsManager):
         self.config = config
         self.running_mode = running_mode
         self._api_url = api_url
-        self._url = url
+        if is_swap:
+            self._url = BinanceAuxiliary.url_perp_ws.value
+        else:
+            self._url = url
         self._api_key = api_key
         self._api_secret = api_secret
         self._queue = queue
@@ -103,7 +106,7 @@ class BinanceWsManager(WsManager):
             params = [self._listen_key['SPOT']]
             if self._send_params:
                 params += self._send_params
-            self.logger.debug(f"subscribe: {params}, url: {self._url}")
+            self.logger.debug(f"subscribe: {params}, url: {self._url}, listen key url:{self._listen_key_url}")
             self.start_subscribe(params)
             self._ping(BinanceAuxiliary.ws_ping_sleep.value,
                        reconnection_time=BinanceAuxiliary.reconnection_time_sleep.value)

--- a/pytradekit/ws/binance_ws.py
+++ b/pytradekit/ws/binance_ws.py
@@ -214,13 +214,13 @@ class BinanceWsManager(WsManager):
         return True
 
     def verify_spot_order_trade(self, msg):
-        if msg[BinanceWebSocket.event_type.value] in msg and msg[
+        if BinanceWebSocket.event_type.value in msg and msg[BinanceWebSocket.event_type.value] in msg and msg[
             BinanceWebSocket.event_type.value] == BinanceWebSocket.execution_report.value:
             return True
         return False
 
     def verify_perp_order_trade(self, msg):
-        if msg[BinanceWebSocket.event_type.value] in msg and msg[
+        if BinanceWebSocket.event_type.value in msg and msg[BinanceWebSocket.event_type.value] in msg and msg[
             BinanceWebSocket.event_type.value] == BinanceWebSocket.perp_order_trade.value:
             return True
         return False

--- a/pytradekit/ws/huobi_ws.py
+++ b/pytradekit/ws/huobi_ws.py
@@ -63,6 +63,12 @@ class HuobiWsManager(WsManager):
             self._subs.append(_rqs_orders)
         self.send_json(_rqs_orders)
 
+    def _send_trade(self):
+        _rqs_orders = {"action": "sub","ch": "trade.clearing#*#0"}
+        if not self._subs:
+            self._subs.append(_rqs_orders)
+        self.send_json(_rqs_orders)
+
     def _ping(self, n_seconds, reconnection_time=None) -> None:
         now_times = get_timestamp_s()
         while True:
@@ -100,7 +106,7 @@ class HuobiWsManager(WsManager):
 
     def start_subscribe(self, params):
         try:
-            print(f"huobi send msg: {params}")
+            print(f"huobi send msg: {params}， url: {self._url}")
             self.send_json(params)
         except Exception as e:
             self.logger.exception(e)
@@ -115,6 +121,7 @@ class HuobiWsManager(WsManager):
                 self.send(json.dumps({'pong': msg['ping']}))
                 return
             if 'action' in msg and msg['action'] == 'ping':
+                self._send_trade()
                 self._pong(msg['data']['ts'])
                 return
             if 'ch' in msg and 'bbo' in msg['ch']:

--- a/pytradekit/ws/huobi_ws.py
+++ b/pytradekit/ws/huobi_ws.py
@@ -127,7 +127,7 @@ class HuobiWsManager(WsManager):
             if 'ch' in msg and 'bbo' in msg['ch']:
                 self._queue.put_nowait(msg)
                 return
-            if 'ch' in msg and 'trade' in msg['ch']:
+            if 'ch' in msg and 'trade' in msg['ch'] and msg['data']:
                 self._queue.put_nowait(msg)
                 return
         except Exception as e:

--- a/pytradekit/ws/huobi_ws.py
+++ b/pytradekit/ws/huobi_ws.py
@@ -106,11 +106,10 @@ class HuobiWsManager(WsManager):
 
     def _on_message(self, _ws, message):
         try:
-            print(message)
-            print(f"huobi ws:{message}")
             if isinstance(message, bytes):
                 message = gzip.decompress(message).decode('utf-8')
             msg = json.loads(message)
+            print(f"huobi ws:{msg}")
             if 'ping' in msg:
                 self.send(json.dumps({'pong': msg['ping']}))
                 return

--- a/pytradekit/ws/huobi_ws.py
+++ b/pytradekit/ws/huobi_ws.py
@@ -128,7 +128,7 @@ class HuobiWsManager(WsManager):
                 self._queue.put_nowait(msg)
                 return
             if 'ch' in msg and 'trade' in msg['ch'] and msg['data']:
-                self._queue.put_nowait(msg)
+                self._queue.put_nowait(msg['data'])
                 return
         except Exception as e:
             self.logger.exception(e)

--- a/pytradekit/ws/huobi_ws.py
+++ b/pytradekit/ws/huobi_ws.py
@@ -106,6 +106,8 @@ class HuobiWsManager(WsManager):
 
     def _on_message(self, _ws, message):
         try:
+            print(message)
+            print(f"huobi ws:{message}")
             if isinstance(message, bytes):
                 message = gzip.decompress(message).decode('utf-8')
             msg = json.loads(message)
@@ -118,7 +120,7 @@ class HuobiWsManager(WsManager):
             if 'ch' in msg and 'bbo' in msg['ch']:
                 self._queue.put_nowait(msg)
                 return
-            if 'ch' in msg and 'orders' in msg['ch']:
+            if 'ch' in msg and 'trade' in msg['ch']:
                 self._queue.put_nowait(msg)
                 return
         except Exception as e:

--- a/pytradekit/ws/huobi_ws.py
+++ b/pytradekit/ws/huobi_ws.py
@@ -100,6 +100,7 @@ class HuobiWsManager(WsManager):
 
     def start_subscribe(self, params):
         try:
+            print(f"huobi send msg: {params}")
             self.send_json(params)
         except Exception as e:
             self.logger.exception(e)

--- a/pytradekit/ws/okex_ws.py
+++ b/pytradekit/ws/okex_ws.py
@@ -104,23 +104,22 @@ class OkexWsManager(WsManager):
 
     def _on_message(self, _ws, message):
         try:
-            pass
-            # print(f"okex: {message}")
-            # if message == 'pong':
-            #     return
-            # msg = json.loads(message)
-            # if 'event' in msg and msg['event'] == 'login':
-            #     if msg['code'] == '0':
-            #         self._send_order()
-            # elif "code" in msg and msg['code'] == '60011':
-            #     self._login()
-            #
-            # #添加 Ticker 数据处理逻辑
-            # if 'arg' in msg and msg['arg']['channel'] == 'tickers' and "data" in msg:
-            #     if self._queue:
-            #         # OKX 数据通常是列表，取出来放入队列
-            #         for item in msg['data']:
-            #             self._queue.put_nowait(item)
+            if message == 'pong':
+                return
+            msg = json.loads(message)
+            print(f"okex msg: {msg}")
+            if 'event' in msg and msg['event'] == 'login':
+                if msg['code'] == '0':
+                    self._send_order()
+            elif "code" in msg and msg['code'] == '60011':
+                self._login()
+
+            #添加 Ticker 数据处理逻辑
+            if 'arg' in msg and msg['arg']['channel'] == 'tickers' and "data" in msg:
+                if self._queue:
+                    # OKX 数据通常是列表，取出来放入队列
+                    for item in msg['data']:
+                        self._queue.put_nowait(item)
 
         except Exception as e:
             self.logger.exception(e)

--- a/pytradekit/ws/okex_ws.py
+++ b/pytradekit/ws/okex_ws.py
@@ -127,7 +127,7 @@ class OkexWsManager(WsManager):
                 if self._queue:
                     # OKX 数据通常是列表，取出来放入队列
                     for item in msg['data']:
-                        if "filled" in msg['state']:
+                        if "filled" in item['state']:
                             self._queue.put_nowait(item)
 
         except Exception as e:

--- a/pytradekit/ws/okex_ws.py
+++ b/pytradekit/ws/okex_ws.py
@@ -104,22 +104,23 @@ class OkexWsManager(WsManager):
 
     def _on_message(self, _ws, message):
         try:
-            print(f"okex: {message}")
-            if message == 'pong':
-                return
-            msg = json.loads(message)
-            if 'event' in msg and msg['event'] == 'login':
-                if msg['code'] == '0':
-                    self._send_order()
-            elif "code" in msg and msg['code'] == '60011':
-                self._login()
-
-            #添加 Ticker 数据处理逻辑
-            if 'arg' in msg and msg['arg']['channel'] == 'tickers' and "data" in msg:
-                if self._queue:
-                    # OKX 数据通常是列表，取出来放入队列
-                    for item in msg['data']:
-                        self._queue.put_nowait(item)
+            pass
+            # print(f"okex: {message}")
+            # if message == 'pong':
+            #     return
+            # msg = json.loads(message)
+            # if 'event' in msg and msg['event'] == 'login':
+            #     if msg['code'] == '0':
+            #         self._send_order()
+            # elif "code" in msg and msg['code'] == '60011':
+            #     self._login()
+            #
+            # #添加 Ticker 数据处理逻辑
+            # if 'arg' in msg and msg['arg']['channel'] == 'tickers' and "data" in msg:
+            #     if self._queue:
+            #         # OKX 数据通常是列表，取出来放入队列
+            #         for item in msg['data']:
+            #             self._queue.put_nowait(item)
 
         except Exception as e:
             self.logger.exception(e)

--- a/pytradekit/ws/okex_ws.py
+++ b/pytradekit/ws/okex_ws.py
@@ -122,6 +122,12 @@ class OkexWsManager(WsManager):
                     for item in msg['data']:
                         self._queue.put_nowait(item)
 
+            if 'arg' in msg and msg['arg']['channel'] == 'orders' and "data" in msg:
+                if self._queue:
+                    # OKX 数据通常是列表，取出来放入队列
+                    for item in msg['data']:
+                        self._queue.put_nowait(item)
+
         except Exception as e:
             self.logger.exception(e)
             self.logger.debug(message)

--- a/pytradekit/ws/okex_ws.py
+++ b/pytradekit/ws/okex_ws.py
@@ -98,6 +98,7 @@ class OkexWsManager(WsManager):
 
     def start_subscribe(self, login_params):
         try:
+            print(f"okex send msg: {login_params}")
             self.send_json(login_params)
         except Exception as e:
             self.logger.exception(e)

--- a/pytradekit/ws/okex_ws.py
+++ b/pytradekit/ws/okex_ws.py
@@ -127,7 +127,7 @@ class OkexWsManager(WsManager):
                 if self._queue:
                     # OKX 数据通常是列表，取出来放入队列
                     for item in msg['data']:
-                        if "filled" in item['state']:
+                        if "filled" == item['state']:
                             self._queue.put_nowait(item)
 
         except Exception as e:

--- a/pytradekit/ws/okex_ws.py
+++ b/pytradekit/ws/okex_ws.py
@@ -127,7 +127,7 @@ class OkexWsManager(WsManager):
                 if self._queue:
                     # OKX 数据通常是列表，取出来放入队列
                     for item in msg['data']:
-                        if "filled" in msg['data']['state']:
+                        if "filled" in msg['state']:
                             self._queue.put_nowait(item)
 
         except Exception as e:

--- a/pytradekit/ws/okex_ws.py
+++ b/pytradekit/ws/okex_ws.py
@@ -104,6 +104,7 @@ class OkexWsManager(WsManager):
 
     def _on_message(self, _ws, message):
         try:
+            print(f"okex: {message}")
             if message == 'pong':
                 return
             msg = json.loads(message)

--- a/pytradekit/ws/okex_ws.py
+++ b/pytradekit/ws/okex_ws.py
@@ -122,11 +122,13 @@ class OkexWsManager(WsManager):
                     for item in msg['data']:
                         self._queue.put_nowait(item)
 
+            #添加 trade
             if 'arg' in msg and msg['arg']['channel'] == 'orders' and "data" in msg:
                 if self._queue:
                     # OKX 数据通常是列表，取出来放入队列
                     for item in msg['data']:
-                        self._queue.put_nowait(item)
+                        if "filled" in msg['data']['state']:
+                            self._queue.put_nowait(item)
 
         except Exception as e:
             self.logger.exception(e)


### PR DESCRIPTION
## 1. 本次 PR 的目的（What & Why）

**新增：**
- 新增多个交易所（Binance、Huobi、Okex）的 WebSocket 交易推送支持
- 新增 Binance 永续合约 WebSocket 连接支持
- 新增 Redis 中 premium（溢价）数据的存储和读取功能
- 新增多个交易所交易相关的枚举类型定义

**修复：**
- 修复 `base_ws_manager.py` 中 WebSocket 回调方法签名不兼容问题（添加 `*args, **kwargs` 参数）
- 修复 `binance_restful.py` 中 `get_swap_last_funding_rate` 方法未传递 `params` 参数的问题
- 修复 `okex_ws.py` 中心跳错误处理逻辑（将 `break` 改为 `continue`）

**优化：**
- 优化 Binance WebSocket 消息处理逻辑，将订单交易验证和订单簿去重逻辑提取为独立方法
- 优化 `redis_operations.py` 中 `set_portfolios` 方法，确保在发布消息前先设置值

**原因：**
- 需要实时接收交易所的订单成交信息，用于交易系统的实时监控和风控
- 支持 Binance 永续合约交易需要独立的 WebSocket 连接
- 溢价数据需要持久化存储以便后续查询和分析

## 2. 主要修改内容（Changes）

### 2.1 WebSocket 基础框架修改
- **`pytradekit/gateway/websocket/base_ws_manager.py`**：
  - 更新 `_on_open`、`_on_close`、`_on_error` 方法签名，添加 `*args, **kwargs` 参数以兼容不同 WebSocket 库的回调接口

### 2.2 Binance WebSocket 增强
- **`pytradekit/ws/binance_ws.py`**：
  - 添加永续合约 WebSocket URL 支持（`BinanceAuxiliary.url_perp_ws`）
  - 新增 `verify_spot_order_trade()` 方法：验证现货订单交易消息
  - 新增 `verify_perp_order_trade()` 方法：验证永续合约订单交易消息
  - 重构 `verify_spot_bookticker_duplicate()` 方法：提取订单簿去重逻辑
  - 优化 `_on_message()` 方法：支持现货和永续合约订单交易消息处理

### 2.3 Huobi WebSocket 增强
- **`pytradekit/ws/huobi_ws.py`**：
  - 新增 `_send_trade()` 方法：订阅交易推送频道 `trade.clearing#*#0`
  - 更新 WebSocket URL 为 v2 版本：`wss://api.huobi.pro/ws/v2`
  - 在 `_on_message()` 中添加交易消息处理逻辑

### 2.4 Okex WebSocket 增强
- **`pytradekit/ws/okex_ws.py`**：
  - 更新 WebSocket URL 为私有频道：`wss://ws.okx.com:8443/ws/v5/private`
  - 在 `_on_message()` 中添加已成交订单（`filled` 状态）的处理逻辑
  - 修复心跳错误处理：将 `break` 改为 `continue`，避免连接中断

### 2.5 类型定义扩展
- **`pytradekit/utils/dynamic_types.py`**：
  - **BinanceWebSocket**：新增永续合约订单交易相关字段
    - `perp_order_trade = 'ORDER_TRADE_UPDATE'`
    - `trade_filled = 'FILLED'`
    - `order_sell = 'SELL'`
    - 永续合约订单相关字段：`perp_order_data`、`perp_order_create_time`、`perp_order_update_time`、`perp_order_status`、`perp_order_fee`、`perp_order_fee_coin`、`perp_order_avg_price`、`perp_order_income`、`perp_liquidation`
    - 资金费率相关字段：`funding_rate_info_symbol`、`funding_interval_hours`
  - **HuobiWebSocket**：新增交易相关字段
    - `order_sell = 'sell'`
    - `order_side = 'orderSide'`
    - `trade_fee = 'transactFee'`
    - `trade_fee_coin = 'feeCurrency'`
    - `trade_filled = 'filled'`
  - **OkexWebSocket**：新增交易相关字段
    - `data = 'data'`
    - `order_sell = 'sell'`
    - `trade_filled = 'filled'`
  - **HuobiAuxiliary**：更新 WebSocket URL 为 v2
  - **OkexAuxiliary**：更新 WebSocket URL 为私有频道
  - **RedisFields**：新增 `premium = auto()`
  - 新增 **PremiumStatus** 枚举类：`open`、`open_pending`、`close`、`close_pending`

### 2.6 Redis 操作扩展
- **`pytradekit/utils/redis_operations.py`**：
  - 新增常量 `PREMIUM_EXPIRE_TIME = TimeConvert.MIN_TO_S * 60 * 24 * 30`（30天过期时间）
  - 新增 `set_target_premium()` 方法：设置订单的目标溢价
  - 新增 `get_target_premium()` 方法：获取订单的目标溢价
  - 优化 `set_portfolios()` 方法：在发布消息前先设置 Redis 值

### 2.7 RESTful API 修复
- **`pytradekit/restful/binance_restful.py`**：
  - 修复 `get_swap_last_funding_rate()` 方法：添加 `params=params` 参数传递

## 3. 是否影响以下关键功能？（Impact Check）

### 交易执行逻辑
- **影响程度**：低
- **说明**：本次修改主要添加了 WebSocket 交易消息的接收和处理，不直接修改交易执行逻辑。交易消息通过队列传递，由下游系统处理。

### 风控逻辑
- **影响程度**：中
- **说明**：新增的交易推送功能可用于实时监控订单成交情况，可能用于风控系统的实时检查。需要确保交易消息的准确性和及时性。

### 交易池确定逻辑
- **影响程度**：无
- **说明**：本次修改不涉及交易池确定逻辑。

## 4. 数据一致性

- **WebSocket 消息处理**：所有交易所的交易消息都通过统一的队列机制传递，确保消息顺序和完整性
- **Redis 数据**：新增的 premium 数据使用锁机制保证并发安全，设置 30 天过期时间
- **枚举类型扩展**：新增的枚举类型与现有类型定义保持一致，不影响现有数据结构

## 5. 测试（Testing）

### 本地测试：
- **单元测试**：
  - 需要测试新增的 `verify_spot_order_trade()`、`verify_perp_order_trade()` 方法
  - 需要测试 `set_target_premium()` 和 `get_target_premium()` 方法
  - 需要测试 `verify_spot_bookticker_duplicate()` 方法的去重逻辑

- **模拟下单测试（mock API）**：
  - 模拟 Binance 现货和永续合约订单交易消息
  - 模拟 Huobi 交易推送消息
  - 模拟 Okex 已成交订单消息
  - 验证消息能够正确进入队列

- **回测验证通过**：
  - 待验证

- **极端情况 / 异常 case 检查**：
  - WebSocket 连接中断时的重连机制
  - 消息格式异常时的错误处理
  - Redis 连接失败时的异常处理

### 部署测试（如有）：
- **Dev 环境跑通**：
  - 待验证

- **日志正常，无 error**：
  - 注意：代码中存在部分 `print()` 语句（`binance_ws.py`、`huobi_ws.py`、`okex_ws.py`），建议后续改为 `logger.debug()` 以符合项目规范

## 6. 风险评估（Risk Assessment）

### 低风险：
- WebSocket 回调方法签名修改：向后兼容，不影响现有功能
- 枚举类型扩展：不影响现有代码逻辑
- Redis premium 操作：新增功能，不影响现有 Redis 操作

### 中风险：
- WebSocket 消息处理逻辑变更：
  - **风险点**：Binance 消息处理逻辑重构，可能影响现有订单簿消息的处理
  - **缓解措施**：保留了原有的去重逻辑，只是提取为独立方法
  - **建议**：在 Dev 环境充分测试订单簿和交易消息的接收

- 交易所 WebSocket URL 变更：
  - **风险点**：Huobi 和 Okex 的 WebSocket URL 变更可能影响现有连接
  - **缓解措施**：URL 变更在配置中，不影响现有连接逻辑
  - **建议**：确认新 URL 的可用性和兼容性

### 高风险：
- 无

## 7. 额外信息（Optional）

### 代码质量建议：
1. **调试代码清理**：代码中存在多处 `print()` 语句用于调试，建议在合并前改为 `logger.debug()`：
   - `binance_ws.py:234`: `print(f"binance : {msg}")`
   - `huobi_ws.py:109, 119`: `print(f"huobi send msg: ...")`, `print(f"huobi ws:{msg}")`
   - `okex_ws.py:101, 111`: `print(f"okex send msg: ...")`, `print(f"okex msg: {msg}")`

2. **错误处理增强**：建议在 WebSocket 消息处理中添加更详细的错误日志和异常处理

3. **测试覆盖**：建议为新增的方法添加单元测试，特别是消息验证逻辑

### 后续优化方向：
- 考虑将不同交易所的交易消息格式统一化处理
- 考虑添加交易消息的统计和监控功能
- 考虑优化 WebSocket 重连机制，减少消息丢失

## 8. Reviewer Checklist（供 reviewer 使用）

- [ ] 检查 WebSocket 回调方法签名修改是否正确，是否影响现有功能
- [ ] 检查 Binance 消息处理逻辑重构是否正确，特别是订单簿去重逻辑
- [ ] 检查新增的交易消息处理逻辑是否正确，消息格式是否符合交易所文档
- [ ] 检查 Redis premium 操作的并发安全性（锁机制）
- [ ] 检查枚举类型定义是否完整，是否遗漏必要字段
- [ ] 检查 WebSocket URL 变更是否正确（Huobi v2、Okex private）
- [ ] 检查错误处理是否完善，异常情况是否能够正确恢复
- [ ] 检查代码中是否存在调试代码（print 语句）需要清理
- [ ] 检查日志级别使用是否符合项目规范（只使用 debug 和 info）
- [ ] 检查代码是否符合 PEP8 规范和项目编码标准
