### PR TITLE
[#98] feat: add SwapPosition/SwapIncome aliases for liquidity_monitor compatibility

### DIFF
--- a/pytradekit/utils/static_types.py
+++ b/pytradekit/utils/static_types.py
@@ -1128,3 +1128,8 @@ class TickSnapshot(Enum):
     bid = auto()
     ask = auto()
     premium = auto()
+
+
+# Aliases for backward compatibility with liquidity_monitor
+SwapPosition = PerpPosition
+SwapIncome = PerpIncome


### PR DESCRIPTION
## 1. 本次 PR 的目的（What & Why）

- **新增**：`SwapPosition` 和 `SwapIncome` 作为 `PerpPosition` 和 `PerpIncome` 的别名
- **原因**：`liquidity_monitor` 的 `exchange_data/swap_position/` 模块导入 `SwapPosition`/`SwapIncome`，而 pytradekit 已将相关类重命名为 `PerpPosition`/`PerpIncome`，导致 import 失败

## 2. 主要修改内容（Changes）

`pytradekit/utils/static_types.py` 末尾新增：

```python
# Aliases for backward compatibility with liquidity_monitor
SwapPosition = PerpPosition
SwapIncome = PerpIncome
```

## 3. 是否影响以下关键功能？（Impact Check）

- **交易执行逻辑**：不影响（仅新增别名，不修改原有类）
- **风控逻辑**：不影响
- **交易池确定逻辑**：不影响

## 4. 数据一致性

无数据变更，仅类名别名映射。

## 5. 测试（Testing）

**本地测试：**
- `liquidity_monitor` Docker 容器使用本 PR 后的 pytradekit 构建成功
- swap_position 入库模块 import 正常

## 6. 风险评估（Risk Assessment）

- 极低风险：只读别名，不改变任何已有类行为

## 7. 额外信息（Optional）

- 配套 PR：halfshade-labs/liquidity_monitor#14（Issue #98 主体）

## 8. Reviewer Checklist

- [ ] 别名指向正确（`PerpPosition`/`PerpIncome`）
- [ ] 不影响现有使用 `PerpPosition` 的代码