### PR TITLE
fix(#99): fix BinanceWsManager ticker websocket pipe blocking

### DIFF
--- a/pytradekit/ws/binance_ws.py
+++ b/pytradekit/ws/binance_ws.py
@@ -231,7 +231,6 @@ class BinanceWsManager(WsManager):
     def _on_message(self, _ws, message):
         msg = json.loads(message)
         try:
-            print(f"binance : {msg}")
             # Ticker data from !ticker@arr is a list
             if isinstance(msg, list) and self._ticker_queue:
                 self._ticker_queue.put_nowait(msg)

--- a/pytradekit/ws/binance_ws.py
+++ b/pytradekit/ws/binance_ws.py
@@ -232,7 +232,11 @@ class BinanceWsManager(WsManager):
         msg = json.loads(message)
         try:
             print(f"binance : {msg}")
-            if BinanceAuxiliary.ws_ping.value in msg:
+            # Ticker data from !ticker@arr is a list
+            if isinstance(msg, list) and self._ticker_queue:
+                self._ticker_queue.put_nowait(msg)
+                return
+            if isinstance(msg, dict) and BinanceAuxiliary.ws_ping.value in msg:
                 self._pong()
             else:
                 if self.verify_perp_order_trade(msg):


### PR DESCRIPTION
## 1. 本次 PR 的目的（What & Why）

- **修复**：`BinanceWsManager._on_message` 中 `print(f"binance : {msg}")` 导致 multiprocessing 子进程 stdout pipe 阻塞
- **新增**：`_on_message` 增加 ticker array（`!ticker@arr`）数据处理，写入 `_ticker_queue`
- **原因**：该 print 每秒输出 800+ symbol 完整 ticker 数据，pipe buffer 填满后子进程阻塞在 print，`put_nowait()` 永远无法执行，导致 `BN_ticker_price` Redis key 始终为空

## 2. 主要修改内容（Changes）

- `pytradekit/ws/binance_ws.py`:
  - 移除 `_on_message` 中的 `print(f"binance : {msg}")`
  - 新增 list 类型消息（ticker array）判断，写入 `_ticker_queue`
  - 保留 dict 类型消息的原有 ping/order/bookticker 处理逻辑

## 3. 是否影响以下关键功能？（Impact Check）

- 交易执行逻辑：❌ 不影响
- 风控逻辑：❌ 不影响
- 交易池确定逻辑：❌ 不影响

## 4. 数据一致性

- ticker price 数据通过 `_ticker_queue` → `SaveBinanceTicker` → Redis 写入，格式与 restful 版本一致（`{symbol: price}`）

## 5. 测试（Testing）

本地测试：
- ✅ 容器内 multiprocessing Queue 传输验证：修复前 queue 始终为空，修复后 8s 内收到 8 批 ticker 数据
- ✅ Redis 验证：`BN_ticker_price` key 正常存在，`BTCUSDT` 价格正确

部署测试：
- ✅ `fetch_bn_ticker_price` 容器正常运行，无 error 日志

## 6. 风险评估（Risk Assessment）

低风险。仅移除一行 debug print，不影响任何业务逻辑。ticker_queue 处理为新增代码路径，仅在传入 `ticker_queue` 参数时生效，不影响现有 order/bookticker 消费者。

## 7. 额外信息（Optional）

- 关联 liquidity_monitor PR：https://github.com/halfshade-labs/liquidity_monitor/pull/15

## 8. Reviewer Checklist（供 reviewer 使用）

- [ ] 确认 `_on_message` 对 list/dict 消息分支处理正确
- [ ] 确认移除 print 不影响其他 ws 消费者