### PR TITLE
perf: fix busy-wait in ws monitor and use sleep_min_time

### DIFF
--- a/pytradekit/gateway/websocket/base_ws_manager.py
+++ b/pytradekit/gateway/websocket/base_ws_manager.py
@@ -1,5 +1,4 @@
 import json
-import time
 
 from threading import Thread, Event, Semaphore
 from websocket import WebSocketApp
@@ -8,6 +7,7 @@ from websocket._abnf import ABNF
 from pytradekit.utils.tools import synchronized
 from pytradekit.utils.dynamic_types import WebsocketStatus
 from pytradekit.utils.exceptions import ExchangeException
+from pytradekit.utils.time_handler import sleep_min_time
 
 
 class BaseWebsocketManager:
@@ -79,6 +79,7 @@ class BaseWebsocketManager:
     def _monitor(self):
         ctr = 0
         while self.status != WebsocketStatus.STOP.name:
+            sleep_min_time(0.01)
             ctr += 1
             if ctr >= 5:
                 ctr = 0
@@ -89,8 +90,6 @@ class BaseWebsocketManager:
                     self._needRecovery.clear()
                     self._recovery()
                     break
-
-            time.sleep(0.01)
 
     def _connect(self):
         assert not self.ws, "ws should be closed before attempting to connect"
@@ -124,7 +123,7 @@ class BaseWebsocketManager:
                 self.ws = None
                 return
             ctr += 1
-            time.sleep(0.01)
+            sleep_min_time(0.01)
         self.status = WebsocketStatus.ACTIVE.name
 
     def _wrap_callback(self, f):


### PR DESCRIPTION
## Summary
- 修复 `_monitor()` 在 RECOVERY/INIT 状态时跳过 `sleep` 的忙等问题（`continue` 跳过了循环底部的 sleep）
- 将 `time.sleep` 移到循环顶部，确保每次迭代都会 sleep
- `import time` 替换为 `from pytradekit.utils.time_handler import sleep_min_time`，保持项目一致性

## Context
`realtime_compute_premium` 容器 CPU 偏高。`_monitor` 线程在 WS 连接恢复期间因 `continue` 跳过 sleep 形成忙等，4 个 WS 连接各一个 monitor 线程同时空转。

## Related
- cross_exchange_arbitrage PR: remove Manager IPC overhead

## Test plan
- [ ] 部署后观察 WS 重连期间 CPU 是否下降
- [ ] 确认 WS 连接断开后能正常恢复

🤖 Generated with [Claude Code](https://claude.com/claude-code)