### PR TITLE
feat: add arbitrage position data storage types and CRUD

### DIFF
--- a/pytradekit/utils/mongodb_operations.py
+++ b/pytradekit/utils/mongodb_operations.py
@@ -22,7 +22,8 @@ from pytradekit.utils.static_types import Database, OrderAttribute, TradeAttribu
     LastAggtradeAttribute, InstcodeBasicAttribute, \
     OrderBookAttribute, OrderDepthRatioAttribute, RankAttribute, BalanceAttribute, DepositWithdrawAttribute, \
     InventoryAttribute, DepthAttribute, PnlAttribute, VolumeFeeAttribute, BudgetAttribute, UserLoanAttribute, \
-    MaxInventoryAttribute, ArbitragePoolsReportAttribute, PerpPositionAttribute, PerpIncomeAttribute
+    MaxInventoryAttribute, ArbitragePoolsReportAttribute, PerpPositionAttribute, PerpIncomeAttribute, \
+    TradeRecordAttribute, PremiumSnapshotAttribute, FundingRateHistoryAttribute
 from pytradekit.utils.dynamic_types import DepositWithdrawAuxiliary, DuplicateFields, ExchangeId
 from pytradekit.utils.custom_types import InstCode
 from pytradekit.utils.exceptions import NoDataException
@@ -1335,3 +1336,91 @@ class MongodbOperations:
         if latest and results:
             return results[0]
         return results
+
+    # ====== Trade Records ======
+
+    def insert_trade_record(self, data):
+        collection_path = CollectionPath(db_name=Database.arbitrage.name,
+                                         collection_name=Database.trade_records.name)
+        if isinstance(data, dict) and TradeRecordAttribute.trade_id.name in data:
+            data["_id"] = data[TradeRecordAttribute.trade_id.name]
+        self.insert_data(data, collection_path)
+
+    def update_trade_record(self, trade_id, update_data):
+        params = {TradeRecordAttribute.trade_id.name: trade_id}
+        update = {'$set': update_data}
+        self.client[Database.arbitrage.name][Database.trade_records.name].update_one(params, update)
+
+    def read_trade_records(self, status=None, strategy_type=None, strategy_id=None, coin=None,
+                           time_span=None, limit=0):
+        params = {}
+        if status:
+            params[TradeRecordAttribute.status.name] = status
+        if strategy_type:
+            params[TradeRecordAttribute.strategy_type.name] = strategy_type
+        if strategy_id:
+            params[TradeRecordAttribute.strategy_id.name] = strategy_id
+        if coin:
+            params[TradeRecordAttribute.coin.name] = coin
+        if time_span:
+            params[TradeRecordAttribute.created_time_ms.name] = {
+                "$gte": time_span.start,
+                "$lte": time_span.end
+            }
+        cursor = self.client[Database.arbitrage.name][Database.trade_records.name].find(params).sort(
+            TradeRecordAttribute.created_time_ms.name, -1)
+        if limit:
+            cursor = cursor.limit(limit)
+        res = list(cursor)
+        return res
+
+    def read_trade_record_by_id(self, trade_id):
+        params = {TradeRecordAttribute.trade_id.name: trade_id}
+        res = self.client[Database.arbitrage.name][Database.trade_records.name].find_one(params)
+        return res
+
+    # ====== Premium Snapshots ======
+
+    def insert_premium_snapshot(self, data):
+        collection_path = CollectionPath(db_name=Database.arbitrage.name,
+                                         collection_name=Database.premium_snapshots.name)
+        self.insert_data(data, collection_path)
+
+    def read_premium_snapshots(self, coin=None, time_span=None, limit=0):
+        params = {}
+        if coin:
+            params[PremiumSnapshotAttribute.coin.name] = coin
+        if time_span:
+            params[PremiumSnapshotAttribute.time_ms.name] = {
+                "$gte": time_span.start,
+                "$lte": time_span.end
+            }
+        cursor = self.client[Database.arbitrage.name][Database.premium_snapshots.name].find(params).sort(
+            PremiumSnapshotAttribute.time_ms.name, -1)
+        if limit:
+            cursor = cursor.limit(limit)
+        return list(cursor)
+
+    # ====== Funding Rate History ======
+
+    def insert_funding_rate_history(self, data):
+        collection_path = CollectionPath(db_name=Database.arbitrage.name,
+                                         collection_name=Database.funding_rate_history.name)
+        self.insert_data(data, collection_path)
+
+    def read_funding_rate_history(self, inst_code=None, exchange_id=None, time_span=None, limit=0):
+        params = {}
+        if inst_code:
+            params[FundingRateHistoryAttribute.inst_code.name] = inst_code
+        if exchange_id:
+            params[FundingRateHistoryAttribute.exchange_id.name] = exchange_id
+        if time_span:
+            params[FundingRateHistoryAttribute.time_ms.name] = {
+                "$gte": time_span.start,
+                "$lte": time_span.end
+            }
+        cursor = self.client[Database.arbitrage.name][Database.funding_rate_history.name].find(params).sort(
+            FundingRateHistoryAttribute.time_ms.name, -1)
+        if limit:
+            cursor = cursor.limit(limit)
+        return list(cursor)

--- a/pytradekit/utils/static_types.py
+++ b/pytradekit/utils/static_types.py
@@ -47,6 +47,10 @@ class Database(Enum):
     max_inventory = auto()
     cross_exchange_arbitrage = auto()
     arbitrage_pools_report = auto()
+    arbitrage = auto()
+    trade_records = auto()
+    premium_snapshots = auto()
+    funding_rate_history = auto()
 
 
 class OrderAttribute(Enum):
@@ -1128,6 +1132,127 @@ class TickSnapshot(Enum):
     bid = auto()
     ask = auto()
     premium = auto()
+
+
+# ====== Arbitrage Position Data Storage ======
+
+class TradeRecordAttribute(Enum):
+    trade_id = auto()
+    strategy_type = auto()
+    strategy_id = auto()
+    coin = auto()
+    status = auto()
+    created_time_ms = auto()
+    updated_time_ms = auto()
+    closed_time_ms = auto()
+    liq_hedge_checked = auto()
+    legs = auto()
+    hedge_status = auto()
+    pnl_summary = auto()
+
+
+class LegAttribute(Enum):
+    inst_code = auto()
+    inst_type = auto()
+    exchange_id = auto()
+    account_id = auto()
+    side = auto()
+    position_size = auto()
+    margin_volume = auto()
+    fee = auto()
+    fee_coin = auto()
+    entry_price = auto()
+    mark_price = auto()
+    liq_price = auto()
+    close_price = auto()
+    realized_pnl = auto()
+    unrealized_pnl = auto()
+    funding_fee_collected = auto()
+    funding_rate_current = auto()
+    funding_rate_annualized = auto()
+    premium = auto()
+    delivery_time_ms = auto()
+    days_to_expiry = auto()
+    roll_plan = auto()
+    updated_time_ms = auto()
+
+
+class HedgeStatusAttribute(Enum):
+    size_volume = auto()
+    size_volume_diff = auto()
+    size_match = auto()
+    usdt_diff = auto()
+    direction_mismatch = auto()
+    target_premium = auto()
+    open_premium = auto()
+    close_premium = auto()
+
+
+class PnlSummaryAttribute(Enum):
+    total_realized = auto()
+    funding_collected = auto()
+    premium_pnl = auto()
+    trading_fee = auto()
+    net_pnl = auto()
+    holding_hours = auto()
+    roi = auto()
+    apy = auto()
+
+
+class PremiumSnapshotAttribute(Enum):
+    time_ms = auto()
+    coin = auto()
+    perp_exchange = auto()
+    spot_exchange = auto()
+    perp_price = auto()
+    spot_price = auto()
+    premium_pct = auto()
+    premium_usdt = auto()
+
+
+class PremiumSnapshot:
+    __slots__ = [attr.name for attr in PremiumSnapshotAttribute]
+
+    def __init__(self, time_ms, coin, perp_exchange, spot_exchange, perp_price, spot_price,
+                 premium_pct, premium_usdt):
+        self.time_ms = time_ms
+        self.coin = coin
+        self.perp_exchange = perp_exchange
+        self.spot_exchange = spot_exchange
+        self.perp_price = perp_price
+        self.spot_price = spot_price
+        self.premium_pct = premium_pct
+        self.premium_usdt = premium_usdt
+
+    def to_dict(self):
+        return {slot: getattr(self, slot) for slot in self.__slots__}
+
+
+class FundingRateHistoryAttribute(Enum):
+    time_ms = auto()
+    exchange_id = auto()
+    inst_code = auto()
+    funding_rate = auto()
+    funding_rate_annualized = auto()
+    mark_price = auto()
+    next_funding_time_ms = auto()
+
+
+class FundingRateHistory:
+    __slots__ = [attr.name for attr in FundingRateHistoryAttribute]
+
+    def __init__(self, time_ms, exchange_id, inst_code, funding_rate, funding_rate_annualized,
+                 mark_price, next_funding_time_ms):
+        self.time_ms = time_ms
+        self.exchange_id = exchange_id
+        self.inst_code = inst_code
+        self.funding_rate = funding_rate
+        self.funding_rate_annualized = funding_rate_annualized
+        self.mark_price = mark_price
+        self.next_funding_time_ms = next_funding_time_ms
+
+    def to_dict(self):
+        return {slot: getattr(self, slot) for slot in self.__slots__}
 
 
 # Aliases for backward compatibility with liquidity_monitor

--- a/tests/test_arbitrage_data_types.py
+++ b/tests/test_arbitrage_data_types.py
@@ -1,0 +1,172 @@
+"""Tests for arbitrage data storage types and MongoDB CRUD methods."""
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from pytradekit.utils.static_types import (
+    Database,
+    TradeRecordAttribute, LegAttribute, HedgeStatusAttribute, PnlSummaryAttribute,
+    PremiumSnapshotAttribute, FundingRateHistoryAttribute,
+    PremiumSnapshot, FundingRateHistory,
+)
+from pytradekit.utils.mongodb_operations import MongodbOperations
+
+
+# === Data Type Tests ===
+
+class TestDatabaseEnum:
+    def test_new_database_entries_exist(self):
+        assert Database.arbitrage.name == "arbitrage"
+        assert Database.trade_records.name == "trade_records"
+        assert Database.premium_snapshots.name == "premium_snapshots"
+        assert Database.funding_rate_history.name == "funding_rate_history"
+
+
+class TestTradeRecordAttribute:
+    def test_all_fields_present(self):
+        expected = [
+            "trade_id", "strategy_type", "strategy_id", "coin", "status",
+            "created_time_ms", "updated_time_ms", "closed_time_ms",
+            "liq_hedge_checked", "legs", "hedge_status", "pnl_summary",
+        ]
+        actual = [a.name for a in TradeRecordAttribute]
+        assert actual == expected
+
+
+class TestLegAttribute:
+    def test_inst_type_field_exists(self):
+        names = [a.name for a in LegAttribute]
+        assert "inst_type" in names
+        assert "inst_code" in names
+        assert "delivery_time_ms" in names
+        assert "roll_plan" in names
+
+
+class TestPremiumSnapshot:
+    def test_to_dict(self):
+        ps = PremiumSnapshot(
+            time_ms=1000, coin="BTC", perp_exchange="BN", spot_exchange="OKX",
+            perp_price=70200.0, spot_price=70100.0, premium_pct=0.00143, premium_usdt=100.0,
+        )
+        d = ps.to_dict()
+        assert d["coin"] == "BTC"
+        assert d["perp_exchange"] == "BN"
+        assert d["premium_pct"] == 0.00143
+        assert d["premium_usdt"] == 100.0
+
+    def test_slots_match_attribute_enum(self):
+        assert PremiumSnapshot.__slots__ == [a.name for a in PremiumSnapshotAttribute]
+
+
+class TestFundingRateHistory:
+    def test_to_dict(self):
+        fr = FundingRateHistory(
+            time_ms=1000, exchange_id="BN", inst_code="BTC-USDT_BN.PERP",
+            funding_rate=0.0002, funding_rate_annualized=0.219,
+            mark_price=70200.0, next_funding_time_ms=2000,
+        )
+        d = fr.to_dict()
+        assert d["inst_code"] == "BTC-USDT_BN.PERP"
+        assert d["funding_rate"] == 0.0002
+        assert d["next_funding_time_ms"] == 2000
+
+    def test_slots_match_attribute_enum(self):
+        assert FundingRateHistory.__slots__ == [a.name for a in FundingRateHistoryAttribute]
+
+
+# === MongoDB CRUD Tests ===
+
+def _make_mongo(mocker):
+    """Create a MongodbOperations instance with mocked client."""
+    mocked_client = MagicMock()
+    mocker.patch('pytradekit.utils.mongodb_operations.MongoClient', return_value=mocked_client)
+    MongodbOperations._client = None
+    mongo = MongodbOperations("mongodb://test:27017")
+    return mongo, mocked_client
+
+
+class TestTradeRecordCRUD:
+    def test_insert_trade_record_sets_id(self, mocker):
+        mongo, client = _make_mongo(mocker)
+        doc = {"trade_id": "abc-123", "status": "open"}
+        mongo.insert_trade_record(doc)
+
+        assert doc["_id"] == "abc-123"
+        collection = client["arbitrage"]["trade_records"]
+        collection.insert_one.assert_called_once()
+
+    def test_update_trade_record(self, mocker):
+        mongo, client = _make_mongo(mocker)
+        mongo.update_trade_record("abc-123", {"status": "close"})
+
+        collection = client["arbitrage"]["trade_records"]
+        collection.update_one.assert_called_once_with(
+            {"trade_id": "abc-123"},
+            {"$set": {"status": "close"}},
+        )
+
+    def test_read_trade_records_by_status(self, mocker):
+        mongo, client = _make_mongo(mocker)
+        mock_cursor = MagicMock()
+        mock_cursor.sort.return_value = mock_cursor
+        mock_cursor.__iter__ = MagicMock(return_value=iter([{"trade_id": "1"}]))
+        client["arbitrage"]["trade_records"].find.return_value = mock_cursor
+
+        result = mongo.read_trade_records(status="open")
+
+        client["arbitrage"]["trade_records"].find.assert_called_once_with({"status": "open"})
+
+    def test_read_trade_record_by_id(self, mocker):
+        mongo, client = _make_mongo(mocker)
+        client["arbitrage"]["trade_records"].find_one.return_value = {"trade_id": "abc"}
+
+        result = mongo.read_trade_record_by_id("abc")
+
+        client["arbitrage"]["trade_records"].find_one.assert_called_once_with({"trade_id": "abc"})
+        assert result["trade_id"] == "abc"
+
+
+class TestPremiumSnapshotCRUD:
+    def test_insert_premium_snapshot(self, mocker):
+        mongo, client = _make_mongo(mocker)
+        data = {"time_ms": 1000, "coin": "BTC"}
+        mongo.insert_premium_snapshot(data)
+
+        collection = client["arbitrage"]["premium_snapshots"]
+        collection.insert_one.assert_called_once()
+
+    def test_read_premium_snapshots_with_coin_filter(self, mocker):
+        mongo, client = _make_mongo(mocker)
+        mock_cursor = MagicMock()
+        mock_cursor.sort.return_value = mock_cursor
+        mock_cursor.__iter__ = MagicMock(return_value=iter([]))
+        client["arbitrage"]["premium_snapshots"].find.return_value = mock_cursor
+
+        mongo.read_premium_snapshots(coin="BTC")
+
+        client["arbitrage"]["premium_snapshots"].find.assert_called_once_with({"coin": "BTC"})
+
+
+class TestFundingRateHistoryCRUD:
+    def test_insert_funding_rate_history(self, mocker):
+        mongo, client = _make_mongo(mocker)
+        data = [{"time_ms": 1000, "inst_code": "BTC-USDT_BN.PERP"}]
+        mongo.insert_funding_rate_history(data)
+
+        collection = client["arbitrage"]["funding_rate_history"]
+        collection.insert_many.assert_called_once()
+
+    def test_read_funding_rate_history_with_inst_code(self, mocker):
+        mongo, client = _make_mongo(mocker)
+        mock_cursor = MagicMock()
+        mock_cursor.sort.return_value = mock_cursor
+        mock_cursor.limit.return_value = mock_cursor
+        mock_cursor.__iter__ = MagicMock(return_value=iter([]))
+        client["arbitrage"]["funding_rate_history"].find.return_value = mock_cursor
+
+        mongo.read_funding_rate_history(inst_code="BTC-USDT_BN.PERP", limit=1)
+
+        client["arbitrage"]["funding_rate_history"].find.assert_called_once_with(
+            {"inst_code": "BTC-USDT_BN.PERP"}
+        )
+        mock_cursor.sort.return_value.limit.assert_called_once_with(1)


### PR DESCRIPTION
## Summary
- Add 3 new MongoDB collections to `Database` enum: `trade_records`, `premium_snapshots`, `funding_rate_history`
- Add `TradeRecordAttribute`, `LegAttribute`, `HedgeStatusAttribute`, `PnlSummaryAttribute`, `PremiumSnapshotAttribute`, `FundingRateHistoryAttribute` enum classes
- Add `PremiumSnapshot` and `FundingRateHistory` data classes with `__slots__` and `to_dict()`
- Add 8 MongoDB CRUD methods in `MongodbOperations`
- Add 15 unit tests

## Related
- cross_exchange_arbitrage#111
- liquidity_monitor#19

## Test plan
- [x] 15 unit tests passing (data type validation + mocked CRUD)
- [ ] Integration test with real MongoDB

🤖 Generated with [Claude Code](https://claude.com/claude-code)