### PR TITLE
fix: handle missing 'data' field in HTX WebSocket messages

### DIFF
--- a/pytradekit/ws/huobi_ws.py
+++ b/pytradekit/ws/huobi_ws.py
@@ -159,15 +159,19 @@ class HuobiWsManager(WsManager):
                 # v2 心跳：
                 # - 公共行情：已经在 start_bookticker_stream/subscribe 里发过订阅，这里只需要回 pong
                 # - 私有频道：继续保持原有 _send_trade 逻辑
+                data = msg.get('data')
+                if data is None:
+                    self.logger.warning(f"huobi ws ping missing data: {msg}")
+                    return
                 if not self.is_public:
                     self._send_trade()
                 # 公共和私有都要回 pong
-                self._pong(msg['data']['ts'])
+                self._pong(data['ts'])
                 return
             if 'ch' in msg and 'bbo' in msg['ch']:
                 self._queue.put_nowait(msg)
                 return
-            if 'ch' in msg and 'trade' in msg['ch'] and msg['data']:
+            if 'ch' in msg and 'trade' in msg['ch'] and msg.get('data'):
                 self._queue.put_nowait(msg['data'])
                 return
             # Log unhandled messages for debugging (auth responses, errors, etc.)


### PR DESCRIPTION
## Summary
- HTX 发送 `invalid.auth.state` 响应时不包含 `data` 字段，导致 `huobi_ws.py` 第 165、170 行触发 `KeyError: 'data'`
- 3/26 当天产生约 1,092 次错误日志（每 5-20 秒一次），严重污染日志
- 改用 `msg.get('data')` 安全访问，ping 处理增加 early return 防止无 data 时继续执行

## Changes
- `huobi_ws.py:165` — ping handler 中 `msg['data']['ts']` → 先 `msg.get('data')`，None 时 warning 并 return
- `huobi_ws.py:170` — trade handler 中 `msg['data']` → `msg.get('data')`

## Test plan
- [ ] 验证 HTX 公共/私有 WebSocket 连接正常收发心跳
- [ ] 确认 `invalid.auth.state` 响应不再产生 KeyError
- [ ] 确认 trade 数据正常入队

🤖 Generated with [Claude Code](https://claude.com/claude-code)