### PR TITLE
fix: thread-safe index init, order_link Redis method, log level compliance

### DIFF
--- a/pytradekit/utils/dynamic_types.py
+++ b/pytradekit/utils/dynamic_types.py
@@ -1351,6 +1351,7 @@ class RedisFields(Enum):
     depth_order_theoretical = auto()
     portfolios = auto()
     premium = auto()
+    order_link = auto()
 
 
 class DuplicateFields(Enum):

--- a/pytradekit/utils/mongodb_operations.py
+++ b/pytradekit/utils/mongodb_operations.py
@@ -7,6 +7,7 @@
 """
 import json
 import re
+import threading
 from decimal import Decimal
 from urllib.parse import urlparse, quote_plus, urlunparse
 import functools
@@ -46,6 +47,7 @@ class CollectionPath:
 class MongodbOperations:
     _client = None
     _indexes_ensured = False
+    _indexes_lock = threading.Lock()
 
     @staticmethod
     def handle_mongodb_errors(default_return=None):
@@ -77,9 +79,10 @@ class MongodbOperations:
             MongodbOperations._client = self._create_client(mongodb_url)
         self.client = MongodbOperations._client
         self.logger = logger
-        if not MongodbOperations._indexes_ensured:
-            self._ensure_indexes()
-            MongodbOperations._indexes_ensured = True
+        with MongodbOperations._indexes_lock:
+            if not MongodbOperations._indexes_ensured:
+                self._ensure_indexes()
+                MongodbOperations._indexes_ensured = True
 
     def _ensure_indexes(self):
         """Create compound indexes for arbitrage and account collections (idempotent)."""

--- a/pytradekit/utils/redis_operations.py
+++ b/pytradekit/utils/redis_operations.py
@@ -9,6 +9,7 @@ TICKER_PRICE_EXPIRE_TIME = TimeConvert.MIN_TO_S * 10
 ORDER_TICKER_EXPIRE_TIME = TimeConvert.MIN_TO_S * 30
 ORDERS_EXPIRE_TIME = TimeConvert.MIN_TO_S * 60
 PREMIUM_EXPIRE_TIME = TimeConvert.MIN_TO_S * 60 * 24 * 30
+ORDER_LINK_EXPIRE_TIME = TimeConvert.DAY_TO_S
 TIMEOUT_SECOND = 5
 
 
@@ -283,6 +284,30 @@ class RedisOperations:
         except Exception as e:
             self.logger.exception(f"Failed to set portfolios for {key}: {e}")
             raise DependencyException(f"Failed to set portfolios for {key}") from e
+
+    def set_order_link(self, spot_client_order_id: str, perp_client_order_id: str):
+        """Store spot→perp client_order_id mapping with 24h TTL."""
+        key = f"{RedisFields.order_link.name}:{spot_client_order_id}"
+        lock = self.get_lock_for_resource(key)
+        try:
+            with lock:
+                self.client.set(key, perp_client_order_id)
+                self.client.expire(key, ORDER_LINK_EXPIRE_TIME)
+        except Exception as e:
+            self.logger.exception(f"Failed to set order link for {spot_client_order_id}: {e}")
+            raise DependencyException(f"Failed to set order link for {spot_client_order_id}") from e
+
+    def get_order_link(self, spot_client_order_id: str) -> str:
+        """Retrieve perp client_order_id for a given spot client_order_id."""
+        key = f"{RedisFields.order_link.name}:{spot_client_order_id}"
+        lock = self.get_lock_for_resource(key)
+        try:
+            with lock:
+                value = self.client.get(key)
+                return value.decode() if isinstance(value, bytes) else value
+        except Exception as e:
+            self.logger.exception(f"Failed to get order link for {spot_client_order_id}: {e}")
+            raise DependencyException(f"Failed to get order link for {spot_client_order_id}") from e
 
     def set_target_premium(self, client_order_id, premium):
         key = f"{RedisFields.premium.name}:{client_order_id}"

--- a/pytradekit/ws/huobi_ws.py
+++ b/pytradekit/ws/huobi_ws.py
@@ -161,7 +161,7 @@ class HuobiWsManager(WsManager):
                 # - 私有频道：继续保持原有 _send_trade 逻辑
                 data = msg.get('data')
                 if data is None:
-                    self.logger.warning(f"huobi ws ping missing data: {msg}")
+                    self.logger.debug(f"huobi ws ping missing data: {msg}")
                     return
                 if not self.is_public:
                     self._send_trade()
@@ -180,14 +180,14 @@ class HuobiWsManager(WsManager):
                 if code == 200:
                     self.logger.info(f"huobi ws auth success")
                 else:
-                    self.logger.error(f"huobi ws auth failed: code={code}, msg={msg.get('message', '')}")
+                    self.logger.info(f"huobi ws auth failed: code={code}, msg={msg.get('message', '')}")
             elif 'action' in msg and msg['action'] == 'sub':
                 code = msg.get('code')
                 ch = msg.get('ch', '')
                 if code == 200:
                     self.logger.info(f"huobi ws subscribed: {ch}")
                 else:
-                    self.logger.error(f"huobi ws subscribe failed: ch={ch}, code={code}, msg={msg.get('message', '')}")
+                    self.logger.info(f"huobi ws subscribe failed: ch={ch}, code={code}, msg={msg.get('message', '')}")
         except Exception as e:
             self.logger.exception(e)
             self.logger.debug(f"huobi message error {message}")


### PR DESCRIPTION
## Summary
- **mongodb_operations**: `_indexes_ensured` 改用 `threading.Lock` 保护，消除多线程竞态条件
- **redis_operations**: 新增 `set_order_link` / `get_order_link` 方法（24h TTL，使用 `TimeConvert.DAY_TO_S`）；新增 `ORDER_LINK_EXPIRE_TIME` 常量；`RedisFields` 枚举添加 `order_link` 字段
- **huobi_ws**: 认证/订阅失败日志从 `error`/`warning` 降级为 `info`/`debug`，符合日志规范

## Test plan
- [ ] 多线程环境下 `MongodbOperations` 实例化不重复创建索引
- [ ] `set_order_link` / `get_order_link` 读写正常，TTL 24h 生效
- [ ] huobi_ws 认证失败不触发 Lark 告警

🤖 Generated with [Claude Code](https://claude.com/claude-code)