### PR TITLE
feat: add ping, create_pubsub, close to RedisOperations

### DIFF
--- a/pytradekit/utils/redis_operations.py
+++ b/pytradekit/utils/redis_operations.py
@@ -329,3 +329,24 @@ class RedisOperations:
         except Exception as e:
             self.logger.exception(f"Failed to get target premium for {order_id}: {e}")
             raise DependencyException(f"Failed to get target premium for {order_id}") from e
+
+    def ping(self):
+        """Verify the Redis connection is alive. Raises DependencyException on failure."""
+        try:
+            self.client.ping()
+        except Exception as e:
+            raise DependencyException("Redis ping failed") from e
+
+    def create_pubsub(self):
+        """Create and return a Redis pubsub object."""
+        try:
+            return self.client.pubsub()
+        except Exception as e:
+            raise DependencyException("Failed to create pubsub") from e
+
+    def close(self):
+        """Close the underlying Redis connection."""
+        try:
+            self.client.close()
+        except Exception as e:
+            self.logger.debug(f"error closing Redis connection (ignored): {e}")


### PR DESCRIPTION
## Summary

- Add `ping()` to verify Redis connection health, raises `DependencyException` on failure
- Add `create_pubsub()` to create a pubsub object through the abstraction layer
- Add `close()` to close the underlying Redis connection

## Motivation

Business projects were calling `redis_ops.client.ping()` / `redis_ops.client.pubsub()` / `redis_ops.client.close()` directly, bypassing the `RedisOperations` abstraction. These methods expose the underlying redis-py API in business code, which violates the project rule that all Redis operations must go through `RedisOperations`.

This PR adds the missing methods so business projects no longer need to import `redis` or access `.client` directly.

## Test plan

- [ ] `ping()` returns normally when Redis is reachable
- [ ] `ping()` raises `DependencyException` when Redis is unreachable
- [ ] `create_pubsub()` returns a functional pubsub object
- [ ] `close()` closes the connection without raising on error

🤖 Generated with [Claude Code](https://claude.com/claude-code)