### PR TITLE
fix: improve error handling for ping/create_pubsub/close in RedisOperations

### DIFF
--- a/pytradekit/utils/redis_operations.py
+++ b/pytradekit/utils/redis_operations.py
@@ -335,6 +335,7 @@ class RedisOperations:
         try:
             self.client.ping()
         except Exception as e:
+            self.logger.exception(f"Redis ping failed: {e}")
             raise DependencyException("Redis ping failed") from e
 
     def create_pubsub(self):
@@ -342,11 +343,13 @@ class RedisOperations:
         try:
             return self.client.pubsub()
         except Exception as e:
+            self.logger.exception(f"Failed to create pubsub: {e}")
             raise DependencyException("Failed to create pubsub") from e
 
     def close(self):
-        """Close the underlying Redis connection."""
+        """Close the underlying Redis connection. Raises DependencyException on failure."""
         try:
             self.client.close()
         except Exception as e:
-            self.logger.debug(f"error closing Redis connection (ignored): {e}")
+            self.logger.exception(f"Failed to close Redis connection: {e}")
+            raise DependencyException("Failed to close Redis connection") from e

--- a/tests/test_redis_operations.py
+++ b/tests/test_redis_operations.py
@@ -1,0 +1,97 @@
+import pytest
+from unittest.mock import MagicMock
+from pytradekit.utils.redis_operations import RedisOperations
+from pytradekit.utils.exceptions import DependencyException
+
+
+@pytest.fixture
+def redis_ops(mocker):
+    mock_client = mocker.MagicMock()
+    mocker.patch('redis.StrictRedis.from_url', return_value=mock_client)
+    mock_logger = mocker.MagicMock()
+    ops = RedisOperations(mock_logger, 'redis://localhost:6379')
+    return ops, mock_client, mock_logger
+
+
+class TestPing:
+    def test_ping_success_delegates_to_client(self, redis_ops):
+        ops, client, _ = redis_ops
+        ops.ping()
+        client.ping.assert_called_once()
+
+    def test_ping_failure_raises_dependency_exception(self, redis_ops):
+        ops, client, _ = redis_ops
+        client.ping.side_effect = Exception("connection refused")
+        with pytest.raises(DependencyException):
+            ops.ping()
+
+    def test_ping_failure_logs_exception(self, redis_ops):
+        ops, client, logger = redis_ops
+        client.ping.side_effect = Exception("connection refused")
+        with pytest.raises(DependencyException):
+            ops.ping()
+        logger.exception.assert_called_once()
+
+    def test_ping_failure_chains_original_exception(self, redis_ops):
+        ops, client, _ = redis_ops
+        original = Exception("connection refused")
+        client.ping.side_effect = original
+        with pytest.raises(DependencyException) as exc_info:
+            ops.ping()
+        assert exc_info.value.__cause__ is original
+
+
+class TestCreatePubsub:
+    def test_create_pubsub_returns_client_pubsub(self, redis_ops):
+        ops, client, _ = redis_ops
+        result = ops.create_pubsub()
+        assert result is client.pubsub.return_value
+
+    def test_create_pubsub_failure_raises_dependency_exception(self, redis_ops):
+        ops, client, _ = redis_ops
+        client.pubsub.side_effect = Exception("pubsub error")
+        with pytest.raises(DependencyException):
+            ops.create_pubsub()
+
+    def test_create_pubsub_failure_logs_exception(self, redis_ops):
+        ops, client, logger = redis_ops
+        client.pubsub.side_effect = Exception("pubsub error")
+        with pytest.raises(DependencyException):
+            ops.create_pubsub()
+        logger.exception.assert_called_once()
+
+    def test_create_pubsub_failure_chains_original_exception(self, redis_ops):
+        ops, client, _ = redis_ops
+        original = Exception("pubsub error")
+        client.pubsub.side_effect = original
+        with pytest.raises(DependencyException) as exc_info:
+            ops.create_pubsub()
+        assert exc_info.value.__cause__ is original
+
+
+class TestClose:
+    def test_close_success_delegates_to_client(self, redis_ops):
+        ops, client, _ = redis_ops
+        ops.close()
+        client.close.assert_called_once()
+
+    def test_close_failure_raises_dependency_exception(self, redis_ops):
+        ops, client, _ = redis_ops
+        client.close.side_effect = Exception("close failed")
+        with pytest.raises(DependencyException):
+            ops.close()
+
+    def test_close_failure_logs_exception(self, redis_ops):
+        ops, client, logger = redis_ops
+        client.close.side_effect = Exception("close failed")
+        with pytest.raises(DependencyException):
+            ops.close()
+        logger.exception.assert_called_once()
+
+    def test_close_failure_chains_original_exception(self, redis_ops):
+        ops, client, _ = redis_ops
+        original = Exception("close failed")
+        client.close.side_effect = original
+        with pytest.raises(DependencyException) as exc_info:
+            ops.close()
+        assert exc_info.value.__cause__ is original


### PR DESCRIPTION
## Summary

Follow-up to PR #43 which added `ping`, `create_pubsub`, and `close` to `RedisOperations`. Addresses error handling inconsistencies identified in code review.

- `ping()` and `create_pubsub()`: add `logger.exception` before re-raising `DependencyException`, consistent with every other method in the class
- `close()`: add `logger.exception` and raise `DependencyException` on failure — previously swallowed all exceptions silently at `debug` level, risking undetected connection leaks (leaked sockets accumulate in Redis `maxclients` across restart cycles)
- Add `tests/test_redis_operations.py` with 12 test cases covering success path, exception propagation, logging, and `__cause__` chaining for all three methods; run in Python 3.11 Docker environment matching deployment

## Test plan

- [x] All 12 new tests pass: `docker run --rm -v $(pwd):/app -w /app python:3.11 bash -c "pip install -r requirements.txt -q && python -m pytest tests/test_redis_operations.py -v"`
- [ ] Verify existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)