### PR TITLE
fix: return Decimal instead of float in get_target_premium

### DIFF
--- a/pytradekit/utils/redis_operations.py
+++ b/pytradekit/utils/redis_operations.py
@@ -1,4 +1,5 @@
 import json
+from decimal import Decimal
 
 import redis
 from pytradekit.utils.dynamic_types import RedisFields
@@ -325,7 +326,7 @@ class RedisOperations:
         lock = self.get_lock_for_resource(key)
         try:
             with lock:
-                return float(self.client.get(key))
+                return Decimal(self.client.get(key).decode())
         except Exception as e:
             self.logger.exception(f"Failed to get target premium for {order_id}: {e}")
             raise DependencyException(f"Failed to get target premium for {order_id}") from e


### PR DESCRIPTION
## Summary
- `get_target_premium` 原来 `return float(self.client.get(key))`，现改为 `return Decimal(self.client.get(key).decode())`
- 补充 `from decimal import Decimal` import

## 问题背景
Code review (C2) 发现 premium 全链路使用 float 违反 Decimal 强制规范。Redis 返回 bytes，直接 float() 转换跳过了精度保护；套利场景中 premium 阈值判断对精度敏感。

## Test plan
- [ ] 运行 pytradekit 测试套件验证无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)