### PR TITLE
fix: rename swap to perp across all exchange clients and fix BN WebSocket stream

### DIFF
--- a/pytradekit/restful/binance_restful.py
+++ b/pytradekit/restful/binance_restful.py
@@ -322,7 +322,7 @@ class BinanceClient:
         datas = data_in + data_out
         return datas
 
-    def get_swap_funding_rate(self, symbol=None, start_time=None, end_time=None, limit=1000):
+    def get_perp_funding_rate(self, symbol=None, start_time=None, end_time=None, limit=1000):
         params = {}
         if symbol:
             params['symbol'] = symbol
@@ -332,37 +332,37 @@ class BinanceClient:
             params['endTime'] = end_time
         if limit:
             params['limit'] = limit
-        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_swap_funding_rate.value,
+        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_perp_funding_rate.value,
                                                 params=params, use_sign=False)
         datas = self.request(HttpMmthod.GET.name, url, use_sign=False)
         return datas
 
-    def get_swap_last_funding_rate(self, symbol=None):
+    def get_perp_last_funding_rate(self, symbol=None):
         params = {}
         if symbol:
             params['symbol'] = symbol
-        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_swap_last_funding_rate.value,
+        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_perp_last_funding_rate.value,
                                                 params=params, use_sign=False)
         datas = self.request(HttpMmthod.GET.name, url, params=params, use_sign=False)
         return datas
 
-    def get_swap_last_funding_rate_info(self):
+    def get_perp_last_funding_rate_info(self):
         params = {}
-        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_swap_last_funding_rate_info.value,
+        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_perp_last_funding_rate_info.value,
                                                 params=params, use_sign=False)
         datas = self.request(HttpMmthod.GET.name, url, use_sign=False)
         return datas
 
-    def get_swap_ticker_price(self, symbol=None):
+    def get_perp_ticker_price(self, symbol=None):
         params = {}
         if symbol:
             params['symbol'] = symbol
-        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_swap_ticker_price.value,
+        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_perp_ticker_price.value,
                                                 params=params, use_sign=False)
         datas = self.request(HttpMmthod.GET.name, url, use_sign=False)
         return datas
 
-    def get_swap_open_interes_hist(self, symbol, period, limit=None, start_time=None, end_time=None):
+    def get_perp_open_interes_hist(self, symbol, period, limit=None, start_time=None, end_time=None):
         params = {}
         params['symbol'] = symbol
         params['period'] = period
@@ -373,12 +373,12 @@ class BinanceClient:
         if end_time:
             params['endTime'] = end_time
 
-        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_swap_open_interes_hist.value,
+        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_perp_open_interes_hist.value,
                                                 params=params)
         datas = self.request(HttpMmthod.GET.name, url, params=params)
         return datas
 
-    def get_swap_all_order(self, symbol, limit=None, start_time=None, end_time=None):
+    def get_perp_all_order(self, symbol, limit=None, start_time=None, end_time=None):
         params = {}
         params['symbol'] = symbol
         if limit:
@@ -388,12 +388,12 @@ class BinanceClient:
         if end_time:
             params['endTime'] = end_time
 
-        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_swap_all_order.value,
+        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_perp_all_order.value,
                                                 params=params)
         datas = self.request(HttpMmthod.GET.name, url, params=params)
         return datas
 
-    def get_swap_force_order(self, symbol, limit=None, start_time=None, end_time=None):
+    def get_perp_force_order(self, symbol, limit=None, start_time=None, end_time=None):
         params = {}
         params['symbol'] = symbol
         if limit:
@@ -403,21 +403,21 @@ class BinanceClient:
         if end_time:
             params['endTime'] = end_time
 
-        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_swap_force_order.value,
+        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_perp_force_order.value,
                                                 params=params)
         datas = self.request(HttpMmthod.GET.name, url, params=params)
         return datas
 
-    def get_swap_position_risk(self, symbol=None):
+    def get_perp_position_risk(self, symbol=None):
         params = {}
         if symbol:
             params['symbol'] = symbol
-        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_swap_position_risk.value,
+        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_perp_position_risk.value,
                                                 params=params)
         datas = self.request(HttpMmthod.GET.name, url, params=params)
         return datas
 
-    def get_swap_income(self, symbol=None, start_time=None, end_time=None, income_type='FUNDING_FEE'):
+    def get_perp_income(self, symbol=None, start_time=None, end_time=None, income_type='FUNDING_FEE'):
         params = {}
         if symbol:
             params['symbol'] = symbol
@@ -426,47 +426,47 @@ class BinanceClient:
         if end_time:
             params['endTime'] = end_time
         params['incomeType'] = income_type
-        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_swap_income.value,
+        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_perp_income.value,
                                                 params=params)
         datas = self.request(HttpMmthod.GET.name, url, params=params)
         return datas
 
-    def get_swap_balance(self):
+    def get_perp_balance(self):
         params = {}
-        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_swap_balance.value,
+        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_perp_balance.value,
                                                 params=params)
         datas = self.request(HttpMmthod.GET.name, url, params=params)
         return datas
 
     def get_nonzero_perp_balances(self) -> list:
         """Return perp account balance dicts where balance != 0."""
-        result = self.get_swap_balance()
+        result = self.get_perp_balance()
         items = result if isinstance(result, list) else []
         return [b for b in items if Decimal(str(b.get('balance') or 0)) != 0]
 
     def get_active_perp_positions(self) -> list:
         """Return open perp position dicts where positionAmt != 0."""
-        result = self.get_swap_position_risk()
+        result = self.get_perp_position_risk()
         items = result if isinstance(result, list) else ([result] if result else [])
         return [p for p in items if Decimal(str(p.get('positionAmt') or 0)) != 0]
 
-    def get_swap_account(self):
+    def get_perp_account(self):
         params = {}
-        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_swap_account.value,
+        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_perp_account.value,
                                                 params=params)
         datas = self.request(HttpMmthod.GET.name, url, params=params)
         return datas
 
-    def get_swap_multi_margin(self):
+    def get_perp_multi_margin(self):
         params = {}
-        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_swap_multi_margin.value,
+        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_perp_multi_margin.value,
                                                 params=params)
         datas = self.request(HttpMmthod.GET.name, url, params=params)
         return datas
 
-    def update_swap_margin_type(self, symbol, margin_type):
+    def update_perp_margin_type(self, symbol, margin_type):
         params = {'symbol': symbol, 'marginType': margin_type}
-        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_swap_margin_type.value,
+        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_perp_margin_type.value,
                                                 params=params)
         datas = self.request(HttpMmthod.GET.name, url, params=params)
         return datas
@@ -636,7 +636,7 @@ class BinanceClient:
             return None
 
 
-class BinanceSwapClient(BinanceClient):
+class BinancePerpClient(BinanceClient):
     def __init__(self, logger, key=None, secret=None, passphrase=None, account_id=None):
         super().__init__(logger, key, secret, passphrase, account_id)
         self._url = BinanceAuxiliary.perp_url.value
@@ -655,7 +655,7 @@ class BinanceSwapClient(BinanceClient):
         """
         params = {'symbol': symbol, 'leverage': leverage}
         url, params, _ = self._make_private_url(
-            url_path=BinanceAuxiliary.url_swap_leverage.value,
+            url_path=BinanceAuxiliary.url_perp_leverage.value,
             params=params
         )
         result = self.request(HttpMmthod.POST.name, url, params=params)
@@ -675,7 +675,7 @@ class BinanceSwapClient(BinanceClient):
         """
         params = {'symbol': symbol, 'marginType': margin_type}
         url, params, _ = self._make_private_url(
-            url_path=BinanceAuxiliary.url_swap_margin_type.value,
+            url_path=BinanceAuxiliary.url_perp_margin_type.value,
             params=params
         )
         result = self.request(HttpMmthod.POST.name, url, params=params)
@@ -707,7 +707,7 @@ class BinanceSwapClient(BinanceClient):
             'newClientOrderId': client_order_id
         }
         url, params, timestamp = self._make_private_url(
-            url_path=BinanceAuxiliary.url_swap_order.value,
+            url_path=BinanceAuxiliary.url_perp_order.value,
             params=params
         )
         datas, err = await self.async_request(HttpMmthod.POST.name, url, http_client=http_client, params=params)
@@ -736,7 +736,7 @@ class BinanceSwapClient(BinanceClient):
             'newClientOrderId': client_order_id
         }
         url, params, timestamp = self._make_private_url(
-            url_path=BinanceAuxiliary.url_swap_order.value,
+            url_path=BinanceAuxiliary.url_perp_order.value,
             params=params
         )
         datas, err = await self.async_request(HttpMmthod.POST.name, url, http_client=http_client, params=params)

--- a/pytradekit/restful/bitget_restful.py
+++ b/pytradekit/restful/bitget_restful.py
@@ -11,7 +11,7 @@ from pytradekit.utils.time_handler import get_timestamp_ms, TimeConvert
 
 
 class BitgetClient:
-    def __init__(self, logger, key=None, secret=None, passphrase=None, account_id=None, is_swap=False):
+    def __init__(self, logger, key=None, secret=None, passphrase=None, account_id=None, is_perp=False):
         self.api_key = key
         self.secret_key = secret
         self.account_id = account_id
@@ -19,8 +19,8 @@ class BitgetClient:
         self.passphrase = passphrase
         self.logger = logger
         self._recvWindow = 5000
-        if is_swap:
-            self._url = BitgetAuxiliary.swap_url.value
+        if is_perp:
+            self._url = BitgetAuxiliary.perp_url.value
         else:
             self._url = BitgetAuxiliary.url.value
 

--- a/pytradekit/restful/bitmart_restful.py
+++ b/pytradekit/restful/bitmart_restful.py
@@ -8,14 +8,14 @@ from pytradekit.utils.time_handler import get_timestamp_ms
 
 
 class BitmartClient:
-    def __init__(self, logger, key=None, secret=None, memo=None, account_id=None, is_swap=False):
+    def __init__(self, logger, key=None, secret=None, memo=None, account_id=None, is_perp=False):
         self.api_key = key
         self.secret_key = secret
         self.memo = memo
         self.account_id = account_id
         self.logger = logger
-        if is_swap:
-            self._url = BitmartAuxiliary.swap_url.value
+        if is_perp:
+            self._url = BitmartAuxiliary.perp_url.value
         else:
             self._url = BitmartAuxiliary.url.value
 

--- a/pytradekit/restful/bullish_restful.py
+++ b/pytradekit/restful/bullish_restful.py
@@ -3,15 +3,15 @@ from pytradekit.utils.dynamic_types import BullishAuxiliary
 
 
 class BullishClient:
-    def __init__(self, logger, key=None, secret=None, account_id=None, is_swap=False):
+    def __init__(self, logger, key=None, secret=None, account_id=None, is_perp=False):
         self.api_key = key
         self.secret_key = secret
         self.account_id = account_id
         self.session = requests.session()
         self.logger = logger
         self._recvWindow = 5000
-        if is_swap:
-            self._url = BullishAuxiliary.swap_url.value
+        if is_perp:
+            self._url = BullishAuxiliary.perp_url.value
         else:
             self._url = BullishAuxiliary.url.value
 

--- a/pytradekit/restful/bybit_restful.py
+++ b/pytradekit/restful/bybit_restful.py
@@ -9,15 +9,15 @@ from pytradekit.utils.dynamic_types import HttpMmthod, BybitAuxiliary
 
 
 class BybitClient:
-    def __init__(self, logger, key=None, secret=None, account_id=None, is_swap=False):
+    def __init__(self, logger, key=None, secret=None, account_id=None, is_perp=False):
         self.api_key = key
         self.secret_key = secret
         self.account_id = account_id
         self.session = requests.session()
         self.logger = logger
         self._recvWindow = 5000
-        if is_swap:
-            self._url = BybitAuxiliary.swap_url.value
+        if is_perp:
+            self._url = BybitAuxiliary.perp_url.value
         else:
             self._url = BybitAuxiliary.url.value
 
@@ -53,15 +53,15 @@ class BybitClient:
         except Exception as e:
             return e
 
-    def get_swap_position(self, symbol):
+    def get_perp_position(self, symbol):
         params = {'category': 'linear', 'symbol': symbol}
-        url = BybitAuxiliary.url_swap_position.value
+        url = BybitAuxiliary.url_perp_position.value
         datas = self._send_request(url, method=HttpMmthod.GET.name, params=params)
         return datas
 
-    def get_swap_interest(self, coin, start_time, end_time):
+    def get_perp_interest(self, coin, start_time, end_time):
         params = {'currency': coin, 'startTime': start_time, 'endTime': end_time}
-        url = BybitAuxiliary.url_swap_interest.value
+        url = BybitAuxiliary.url_perp_interest.value
         datas = self._send_request(url, method=HttpMmthod.GET.name, params=params)
         return datas
 

--- a/pytradekit/restful/exmo_restful.py
+++ b/pytradekit/restful/exmo_restful.py
@@ -7,14 +7,14 @@ from pytradekit.utils.time_handler import get_timestamp_ms, get_timestamp_s
 
 
 class ExmoClient:
-    def __init__(self, logger, key=None, secret=None, account_id=None, is_swap=False):
+    def __init__(self, logger, key=None, secret=None, account_id=None, is_perp=False):
         self.api_key = key
         self.secret_key = secret
         self.account_id = account_id
         self.session = requests.session()
         self.logger = logger
-        if is_swap:
-            self._url = ExmoAuxiliary.swap_url.value
+        if is_perp:
+            self._url = ExmoAuxiliary.perp_url.value
         else:
             self._url = ExmoAuxiliary.url.value
 

--- a/pytradekit/restful/gateio_restful.py
+++ b/pytradekit/restful/gateio_restful.py
@@ -10,15 +10,15 @@ RETRY_FREQUENCY = 3
 
 
 class GateioClient:
-    def __init__(self, logger, key=None, secret=None, account_id=None, is_swap=False):
+    def __init__(self, logger, key=None, secret=None, account_id=None, is_perp=False):
         self.api_key = key
         self.secret_key = secret
         self.account_id = account_id
         self.session = requests.session()
         self.logger = logger
         self._recvWindow = 5000
-        if is_swap:
-            self._url = GateioAuxiliary.swap_url.value
+        if is_perp:
+            self._url = GateioAuxiliary.perp_url.value
         else:
             self._url = GateioAuxiliary.url.value
 
@@ -123,18 +123,18 @@ class GateioClient:
         datas = self._send_request(url, method=HttpMmthod.GET.name, params=params, use_sign=True)
         return datas
 
-    def get_swap_position_risk(self, settle):
-        url = GateioAuxiliary.url_swap_position.value + settle + GateioAuxiliary.url_swap_position_risk.value
+    def get_perp_position_risk(self, settle):
+        url = GateioAuxiliary.url_perp_position.value + settle + GateioAuxiliary.url_perp_position_risk.value
         datas = self._send_request(url, method=HttpMmthod.GET.name, use_sign=True)
         return datas
 
-    def get_swap_account(self, settle):
-        url = GateioAuxiliary.url_swap_position.value + settle + GateioAuxiliary.url_swap_position_accounts.value
+    def get_perp_account(self, settle):
+        url = GateioAuxiliary.url_perp_position.value + settle + GateioAuxiliary.url_perp_position_accounts.value
         datas = self._send_request(url, method=HttpMmthod.GET.name, use_sign=True)
         return datas
 
-    def get_swap_income(self, settle, start_time, end_time):
-        url = GateioAuxiliary.url_swap_position.value + settle + GateioAuxiliary.url_swap_position_income.value
+    def get_perp_income(self, settle, start_time, end_time):
+        url = GateioAuxiliary.url_perp_position.value + settle + GateioAuxiliary.url_perp_position_income.value
         params = {
             'from': start_time,
             'to': end_time,

--- a/pytradekit/restful/hashkey_restful.py
+++ b/pytradekit/restful/hashkey_restful.py
@@ -12,15 +12,15 @@ RETRY_FREQUENCY = 3
 
 
 class HashkeyClient:
-    def __init__(self, logger, key=None, secret=None, account_id=None, is_swap=False):
+    def __init__(self, logger, key=None, secret=None, account_id=None, is_perp=False):
         self.api_key = key
         self.secret_key = secret
         self.account_id = account_id
         self.session = requests.session()
         self.logger = logger
         self._recvWindow = 5000
-        if is_swap:
-            self._url = HashkeyAuxiliary.swap_url.value
+        if is_perp:
+            self._url = HashkeyAuxiliary.perp_url.value
         else:
             self._url = HashkeyAuxiliary.url.value
 

--- a/pytradekit/restful/huobi_restful.py
+++ b/pytradekit/restful/huobi_restful.py
@@ -11,14 +11,14 @@ from pytradekit.utils.static_types import FeeStructureKey
 
 
 class HuobiClient:
-    def __init__(self, logger, key=None, secret=None, account_id=None, is_swap=False):
+    def __init__(self, logger, key=None, secret=None, account_id=None, is_perp=False):
         self.api_key = key
         self.secret_key = secret
         self.account_id = account_id
         self.session = requests.session()
         self.logger = logger
-        if is_swap:
-            self._url = HuobiAuxiliary.swap_url.value
+        if is_perp:
+            self._url = HuobiAuxiliary.perp_url.value
         else:
             self._url = HuobiAuxiliary.url.value
 
@@ -76,21 +76,21 @@ class HuobiClient:
         except Exception as e:
             return e
 
-    def get_swap_position(self, symbol):
+    def get_perp_position(self, symbol):
         params = {'contract_code': symbol}
-        url = HuobiAuxiliary.url_swap_position_info.value
+        url = HuobiAuxiliary.url_perp_position_info.value
         datas = self._send_request(url, method=HttpMmthod.POST.name, params=params)
         return datas
 
-    def get_swap_cross_position(self, symbol):
+    def get_perp_cross_position(self, symbol):
         params = {'contract_code': symbol}
-        url = HuobiAuxiliary.url_swap_cross_position_info.value
+        url = HuobiAuxiliary.url_perp_cross_position_info.value
         datas = self._send_request(url, method=HttpMmthod.POST.name, params=params)
         return datas
 
-    def get_swap_financial_record(self, symbol, start_time, end_time, types):
+    def get_perp_financial_record(self, symbol, start_time, end_time, types):
         params = {'mar_acct': symbol, 'start_time': start_time, 'end_time': end_time, 'type': types, 'direct': 'prev'}
-        url = HuobiAuxiliary.url_swap_financial_record.value
+        url = HuobiAuxiliary.url_perp_financial_record.value
         datas = self._send_request(url, method=HttpMmthod.POST.name, params=params)
         return datas
 
@@ -167,9 +167,9 @@ class HuobiClient:
         datas = self._send_request(url, method=HttpMmthod.GET.name, params=params, use_sign=True)
         return datas
 
-    def get_swap_balances(self):
+    def get_perp_balances(self):
         params = {'valuation_asset': 'USDT'}
-        url = HuobiAuxiliary.url_swap_balance.value
+        url = HuobiAuxiliary.url_perp_balance.value
         datas = self._send_request(url, method=HttpMmthod.POST.name, params=params)
         return datas
 

--- a/pytradekit/restful/kucoin_restful.py
+++ b/pytradekit/restful/kucoin_restful.py
@@ -8,14 +8,14 @@ from pytradekit.utils.dynamic_types import HttpMmthod, KucoinAuxiliary
 
 
 class KucoinClient:
-    def __init__(self, logger, key=None, secret=None, passphrase=None, account_id=None, is_swap=False):
+    def __init__(self, logger, key=None, secret=None, passphrase=None, account_id=None, is_perp=False):
         self.api_key = key
         self.secret_key = secret
         self.passphrase = passphrase
         self.account_id = account_id
         self.logger = logger
-        if is_swap:
-            self._url = KucoinAuxiliary.swap_url.value
+        if is_perp:
+            self._url = KucoinAuxiliary.perp_url.value
         else:
             self._url = KucoinAuxiliary.url.value
 

--- a/pytradekit/restful/lbank_restful.py
+++ b/pytradekit/restful/lbank_restful.py
@@ -7,14 +7,14 @@ from pytradekit.utils.time_handler import get_timestamp_ms, get_timestamp_s
 
 
 class LbankClient:
-    def __init__(self, logger, key=None, secret=None, account_id=None, is_swap=False):
+    def __init__(self, logger, key=None, secret=None, account_id=None, is_perp=False):
         self.api_key = key
         self.secret_key = secret
         self.account_id = account_id
         self.session = requests.session()
         self.logger = logger
-        if is_swap:
-            self._url = LbankAuxiliary.swap_url.value
+        if is_perp:
+            self._url = LbankAuxiliary.perp_url.value
         else:
             self._url = LbankAuxiliary.url.value
 

--- a/pytradekit/restful/mercado_restful.py
+++ b/pytradekit/restful/mercado_restful.py
@@ -6,14 +6,14 @@ from pytradekit.utils.time_handler import get_timestamp_ms
 
 
 class MercadoClient:
-    def __init__(self, logger, key=None, secret=None, account_id=None, is_swap=False):
+    def __init__(self, logger, key=None, secret=None, account_id=None, is_perp=False):
         self.api_key = key
         self.secret_key = secret
         self.account_id = account_id
         self.session = requests.session()
         self.logger = logger
-        if is_swap:
-            self._url = MercadoAuxiliary.swap_url.value
+        if is_perp:
+            self._url = MercadoAuxiliary.perp_url.value
         else:
             self._url = MercadoAuxiliary.url.value
 

--- a/pytradekit/restful/mexc_restful.py
+++ b/pytradekit/restful/mexc_restful.py
@@ -7,13 +7,13 @@ from pytradekit.utils.dynamic_types import HttpMmthod, MexcAuxiliary
 
 
 class MexcClient:
-    def __init__(self, logger, key=None, secret=None, account_id=None, is_swap=False):
+    def __init__(self, logger, key=None, secret=None, account_id=None, is_perp=False):
         self.api_key = key
         self.secret_key = secret
         self.account_id = account_id
         self.logger = logger
-        if is_swap:
-            self._url = MexcAuxiliary.swap_url.value
+        if is_perp:
+            self._url = MexcAuxiliary.perp_url.value
         else:
             self._url = MexcAuxiliary.url.value
 

--- a/pytradekit/restful/okex_restful.py
+++ b/pytradekit/restful/okex_restful.py
@@ -11,15 +11,15 @@ from pytradekit.utils.static_types import FeeStructureKey
 
 
 class OkexClient:
-    def __init__(self, logger, key=None, secret=None, passphrase=None, account_id=None, is_swap=False):
+    def __init__(self, logger, key=None, secret=None, passphrase=None, account_id=None, is_perp=False):
         self.api_key = key
         self.secret_key = secret
         self.account_id = account_id
         self.passphrase = passphrase
         self.session = requests.session()
         self.logger = logger
-        if is_swap:
-            self._url = OkexAuxiliary.swap_url.value
+        if is_perp:
+            self._url = OkexAuxiliary.perp_url.value
         else:
             self._url = OkexAuxiliary.url.value
 
@@ -64,15 +64,15 @@ class OkexClient:
         except Exception as e:
             return e
 
-    def get_swap_position(self, symbol):
+    def get_perp_position(self, symbol):
         params = {'instType': InstCodeType.SWAP.name, 'instId': symbol + "-" + InstCodeType.SWAP.name}
-        url = OkexAuxiliary.url_swap_position.value
+        url = OkexAuxiliary.url_perp_position.value
         datas = self._send_request(url, method=HttpMmthod.GET.name, params=params)
         return datas
 
-    def get_swap_interest(self, start_time, end_time):
+    def get_perp_interest(self, start_time, end_time):
         params = {'after': start_time, 'before': end_time}
-        url = OkexAuxiliary.url_swap_interest.value
+        url = OkexAuxiliary.url_perp_interest.value
         datas = self._send_request(url, method=HttpMmthod.GET.name, params=params)
         return datas
 

--- a/pytradekit/restful/wazirx_restful.py
+++ b/pytradekit/restful/wazirx_restful.py
@@ -3,15 +3,15 @@ from pytradekit.utils.dynamic_types import WazirxAuxiliary
 
 
 class WazirxClient:
-    def __init__(self, logger, key=None, secret=None, account_id=None, is_swap=False):
+    def __init__(self, logger, key=None, secret=None, account_id=None, is_perp=False):
         self.api_key = key
         self.secret_key = secret
         self.account_id = account_id
         self.session = requests.session()
         self.logger = logger
         self._recvWindow = 5000
-        if is_swap:
-            self._url = WazirxAuxiliary.swap_url.value
+        if is_perp:
+            self._url = WazirxAuxiliary.perp_url.value
         else:
             self._url = WazirxAuxiliary.url.value
 

--- a/pytradekit/restful/woox_restful.py
+++ b/pytradekit/restful/woox_restful.py
@@ -10,13 +10,13 @@ from pytradekit.utils.time_handler import get_timestamp_ms
 
 
 class WooxClient:
-    def __init__(self, logger, key=None, secret=None, account_id=None, is_swap=False):
+    def __init__(self, logger, key=None, secret=None, account_id=None, is_perp=False):
         self.api_key = key
         self.secret_key = secret
         self.account_id = account_id
         self.logger = logger
-        if is_swap:
-            self._url = WooxAuxiliary.swap_url.value
+        if is_perp:
+            self._url = WooxAuxiliary.perp_url.value
         else:
             self._url = WooxAuxiliary.url.value
 

--- a/pytradekit/trading_setup/exchange_fees.py
+++ b/pytradekit/trading_setup/exchange_fees.py
@@ -382,23 +382,23 @@ class FeeRateResolver:
                     is_perp=is_perp
                 )
             elif exchange_id == ExchangeId.HTX.name:
-                is_swap = (market_type == InstCodeType.PERP.name.lower())
+                is_perp = (market_type == InstCodeType.PERP.name.lower())
                 return HuobiClient(
                     logger=self.logger,
                     key=api_key,
                     secret=api_secret,
                     account_id=account_id,
-                    is_swap=is_swap
+                    is_perp=is_perp
                 )
             elif exchange_id == ExchangeId.OKX.name:
-                is_swap = (market_type == InstCodeType.PERP.name.lower())
+                is_perp = (market_type == InstCodeType.PERP.name.lower())
                 return OkexClient(
                     logger=self.logger,
                     key=api_key,
                     secret=api_secret,
                     passphrase=api_passphrase,
                     account_id=account_id,
-                    is_swap=is_swap
+                    is_perp=is_perp
                 )
             return None
         except Exception as e:

--- a/pytradekit/utils/dynamic_types.py
+++ b/pytradekit/utils/dynamic_types.py
@@ -56,12 +56,12 @@ class TaskIdName(Enum):
     rs_003 = 'rs_bfx_balance'
     ws_008 = 'ws_bn_deposit_withdraw'
     ws_009 = 'fetch_ws_ticker'
-    rs_swap_001 = 'ws_bn_swap_position'
-    rs_swap_002 = 'push_slack_hedge_report'
-    rs_swap_003 = 'fetch_restful_bn_swap_position'
-    rs_swap_004 = 'fetch_restful_hb_swap_position'
-    rs_swap_005 = 'fetch_restful_okex_swap_position'
-    rs_swap_006 = 'fetch_restful_bit_swap_position'
+    rs_perp_001 = 'ws_bn_perp_position'
+    rs_perp_002 = 'push_slack_hedge_report'
+    rs_perp_003 = 'fetch_restful_bn_perp_position'
+    rs_perp_004 = 'fetch_restful_hb_perp_position'
+    rs_perp_005 = 'fetch_restful_okex_perp_position'
+    rs_perp_006 = 'fetch_restful_bit_perp_position'
 
 
 class SlackUser(Enum):
@@ -881,7 +881,7 @@ class BinanceAuxiliary(Enum):
     url_ws_base = 'wss://stream.binance.com:9443'
     url_perp_ws = 'wss://fstream.binance.com/ws'
     user_data_stream = '/api/v3/userDataStream'
-    user_swap_data_stream = '/fapi/v1/listenKey'
+    user_perp_data_stream = '/fapi/v1/listenKey'
     url_ticker_24hr = '/api/v3/ticker/24hr'
     url_perp_ticker_24hr = '/fapi/v1/ticker/24hr'
     url_balance = '/api/v3/account'
@@ -901,26 +901,26 @@ class BinanceAuxiliary(Enum):
     url_withdraw_history = '/sapi/v1/capital/withdraw/history'
     url_transfer_history = '/sapi/v1/sub-account/sub/transfer/history'
     url_transfer_sub_history = '/sapi/v1/sub-account/transfer/subUserHistory'
-    url_swap_funding_rate = '/fapi/v1/fundingRate'
-    url_swap_last_funding_rate = "/fapi/v1/premiumIndex"
-    url_swap_last_funding_rate_info = "/fapi/v1/fundingInfo"
-    url_swap_ticker_price = '/fapi/v2/ticker/price'
-    url_swap_all_order = '/fapi/v1/allOrders'
-    url_swap_force_order = '/fapi/v1/forceOrders'
-    url_swap_position_risk = '/fapi/v3/positionRisk'
-    url_swap_income = '/fapi/v1/income'
-    url_swap_balance = '/fapi/v2/balance'
-    url_swap_account = '/fapi/v2/account'
-    url_swap_multi_margin = '/fapi/v1/multiAssetsMargin'
-    url_swap_margin_type = '/fapi/v1/marginType'
-    url_swap_leverage = '/fapi/v1/leverage'  # 合约杠杆设置API
-    url_swap_order = '/fapi/v1/order'  # 合约下单API
-    url_swap_open_interes_hist = '/futures/data/openInterestHist'
+    url_perp_funding_rate = '/fapi/v1/fundingRate'
+    url_perp_last_funding_rate = "/fapi/v1/premiumIndex"
+    url_perp_last_funding_rate_info = "/fapi/v1/fundingInfo"
+    url_perp_ticker_price = '/fapi/v2/ticker/price'
+    url_perp_all_order = '/fapi/v1/allOrders'
+    url_perp_force_order = '/fapi/v1/forceOrders'
+    url_perp_position_risk = '/fapi/v3/positionRisk'
+    url_perp_income = '/fapi/v1/income'
+    url_perp_balance = '/fapi/v2/balance'
+    url_perp_account = '/fapi/v2/account'
+    url_perp_multi_margin = '/fapi/v1/multiAssetsMargin'
+    url_perp_margin_type = '/fapi/v1/marginType'
+    url_perp_leverage = '/fapi/v1/leverage'  # 合约杠杆设置API
+    url_perp_order = '/fapi/v1/order'  # 合约下单API
+    url_perp_open_interes_hist = '/futures/data/openInterestHist'
     url_alpha_exchange_info = "/bapi/defi/v1/public/wallet-direct/buw/wallet/cex/alpha/all/token/list"
     url_commission_rate = '/fapi/v1/commissionRate'  # Futures commission rate
     url_spot_commission_rate = '/api/v3/account/commission'  # Spot commission rate
     ws_aggtrade = "@aggTrade"
-    ws_ticker = "!ticker@arr"
+    ws_ticker = "!miniTicker@arr"
     ws_kline_interval = '@kline_15m'
     ws_book_ticker = '@bookTicker'
     ws_orderbook = '@depth'
@@ -956,10 +956,10 @@ class HuobiAuxiliary(Enum):
     url_ws_private = 'wss://api.huobi.pro/ws/v2'
     url_exchange = '/v2/settings/common/symbols'
     url_ticker = '/market/tickers'
-    swap_url = 'https://api.hbdm.com'
-    url_swap_cross_position_info = '/linear-swap-api/v1/swap_cross_position_info'
-    url_swap_position_info = '/linear-swap-api/v1/swap_position_info'
-    url_swap_financial_record = '/linear-swap-api/v3/swap_financial_record'
+    perp_url = 'https://api.hbdm.com'
+    url_perp_cross_position_info = '/linear-swap-api/v1/swap_cross_position_info'
+    url_perp_position_info = '/linear-swap-api/v1/swap_position_info'
+    url_perp_financial_record = '/linear-swap-api/v3/swap_financial_record'
     url_orderbook = '/market/depth'
     url_account = '/v1/account/accounts'
     url_balance = '/v1/account/accounts/{}/balance'
@@ -968,7 +968,7 @@ class HuobiAuxiliary(Enum):
     url_orders = '/v1/order/history'
     url_trades = '/v1/order/matchresults'
     url_spot_order = '/v1/order/orders/place'  # 现货下单API
-    url_swap_balance = '/linear-swap-api/v1/swap_balance_valuation'
+    url_perp_balance = '/linear-swap-api/v1/swap_balance_valuation'
     url_commission_rate = '/v2/reference/transact-fee-rate/get'
     ws_ping_sleep = 1800
     reconnection_time_sleep = 60 * 60 * 2
@@ -979,9 +979,9 @@ class OkexAuxiliary(Enum):
     url_ws = 'wss://ws.okx.com:8443/ws/v5/private'
     url_ws_public = 'wss://ws.okx.com:8443/ws/v5/public'
     url_ws_private = 'wss://ws.okx.com:8443/ws/v5/private'
-    swap_url = 'https://www.okx.com'
-    url_swap_position = '/api/v5/account/positions'
-    url_swap_interest = '/api/v5/account/interest-accrued'
+    perp_url = 'https://www.okx.com'
+    url_perp_position = '/api/v5/account/positions'
+    url_perp_interest = '/api/v5/account/interest-accrued'
     url_exchange = '/api/v5/public/instruments'
     url_ticker = '/api/v5/market/tickers'
     url_orderbook = '/api/v5/market/books-full'
@@ -1002,9 +1002,9 @@ class OkexAuxiliary(Enum):
 class BybitAuxiliary(Enum):
     url = 'https://api.bybit.com'
     url_ws = 'wss://stream.bybit.com/v5/private'
-    swap_url = 'https://api.bybit.com'
-    url_swap_position = '/v5/position/list'
-    url_swap_interest = '/v5/account/borrow-history'
+    perp_url = 'https://api.bybit.com'
+    url_perp_position = '/v5/position/list'
+    url_perp_interest = '/v5/account/borrow-history'
     url_exchange = '/v5/market/instruments-info'
     url_ticker = '/v5/market/tickers'
     url_orderbook = '/v5/market/orderbook'
@@ -1023,7 +1023,7 @@ class BybitAuxiliary(Enum):
 class KucoinAuxiliary(Enum):
     url = 'https://api.kucoin.com'
     url_ws = 'wss://ws-api-spot.kucoin.com'
-    swap_url = 'https://api.kucoin.com'
+    perp_url = 'https://api.kucoin.com'
     url_tickers = '/api/v1/market/allTickers'
     url_ticker = '/api/v1/market/orderbook/level1'
     url_exchange = '/api/v2/symbols'
@@ -1041,7 +1041,7 @@ class KucoinAuxiliary(Enum):
 
 class MexcAuxiliary(Enum):
     url = 'https://api.mexc.com'
-    swap_url = 'https://api.mexc.com'
+    perp_url = 'https://api.mexc.com'
     url_ticker = '/api/v3/ticker/24hr'
     url_exchange = '/api/v3/exchangeInfo'
     url_orderbook = '/api/v3/depth'
@@ -1056,7 +1056,7 @@ class MexcAuxiliary(Enum):
 
 class GateioAuxiliary(Enum):
     url = 'https://api.gateio.ws'
-    swap_url = 'https://api.gateio.ws'
+    perp_url = 'https://api.gateio.ws'
     url_ticker = '/api/v4/spot/tickers'
     url_exchange = '/api/v4/spot/currency_pairs'
     url_orderbook = '/api/v4/spot/order_book'
@@ -1066,15 +1066,15 @@ class GateioAuxiliary(Enum):
     url_transfer_history = '/api/v4/wallet/sub_account_transfers'
     url_orders = '/api/v4/spot/orders'
     url_trades = '/api/v4/spot/my_trades'
-    url_swap_position = '/api/v4/futures/'
-    url_swap_position_risk = '/positions'
-    url_swap_position_accounts = '/accounts'
-    url_swap_position_income = '/account_book'
+    url_perp_position = '/api/v4/futures/'
+    url_perp_position_risk = '/positions'
+    url_perp_position_accounts = '/accounts'
+    url_perp_position_income = '/account_book'
 
 
 class BitgetAuxiliary(Enum):
     url = 'https://api.bitget.com'
-    swap_url = 'https://api.bitget.com'
+    perp_url = 'https://api.bitget.com'
     url_exchange = '/api/v2/spot/public/symbols'
     url_ticker = '/api/v2/spot/market/tickers'
     url_orderbook = '/api/v2/spot/market/orderbook'
@@ -1088,7 +1088,7 @@ class BitgetAuxiliary(Enum):
 
 class WazirxAuxiliary(Enum):
     url = 'https://api.wazirx.com'
-    swap_url = 'https://api.wazirx.com'
+    perp_url = 'https://api.wazirx.com'
     url_exchange = '/sapi/v1/exchangeInfo'
     url_ticker = '/sapi/v1/tickers/24hr'
     url_orderbook = '/sapi/v1/depth'
@@ -1097,7 +1097,7 @@ class WazirxAuxiliary(Enum):
 
 class BullishAuxiliary(Enum):
     url = 'https://api.exchange.bullish.com/trading-api'
-    swap_url = 'https://api.exchange.bullish.com/trading-api'
+    perp_url = 'https://api.exchange.bullish.com/trading-api'
     url_exchange = '/v1/markets'
     url_ticker = '/tick'
     url_orderbook = '/orderbook/hybrid'
@@ -1105,7 +1105,7 @@ class BullishAuxiliary(Enum):
 
 class HashkeyAuxiliary(Enum):
     url = 'https://api-glb.hashkey.com'
-    swap_url = 'https://api-glb.hashkey.com'
+    perp_url = 'https://api-glb.hashkey.com'
     url_exchange = '/api/v1/exchangeInfo'
     url_ticker = '/quote/v1/ticker/24hr'
     url_orderbook = '/quote/v1/depth'
@@ -1116,7 +1116,7 @@ class HashkeyAuxiliary(Enum):
 
 class MercadoAuxiliary(Enum):
     url = 'https://api.mercadobitcoin.net/api/v4'
-    swap_url = 'https://api.mercadobitcoin.net/api/v4'
+    perp_url = 'https://api.mercadobitcoin.net/api/v4'
     url_exchange = '/symbols'
     url_orderbook = '/orderbook'
     url_ticker = '/tickers'
@@ -1129,7 +1129,7 @@ class MercadoAuxiliary(Enum):
 
 class BitmartAuxiliary(Enum):
     url = 'https://api-cloud.bitmart.com'
-    swap_url = 'https://api-cloud.bitmart.com'
+    perp_url = 'https://api-cloud.bitmart.com'
     url_exchange = '/spot/v1/symbols/details'
     url_tickers = '/spot/quotation/v3/tickers'
     url_ticker = '/spot/quotation/v3/ticker'
@@ -1145,7 +1145,7 @@ class BitmartAuxiliary(Enum):
 
 class ExmoAuxiliary(Enum):
     url = 'https://api.exmo.com/v1.1'
-    swap_url = 'https://api.exmo.com/v1.1'
+    perp_url = 'https://api.exmo.com/v1.1'
     url_exchange = '/pair_settings'
     url_orderbook = '/order_book'
     url_ticker = '/ticker'
@@ -1158,7 +1158,7 @@ class ExmoAuxiliary(Enum):
 
 class WooxAuxiliary(Enum):
     url = 'https://api.woox.io'
-    swap_url = 'https://api.woox.io'
+    perp_url = 'https://api.woox.io'
     url_version_v1 = '/v1'
     url_version_v3 = '/v3'
     url_exchange = '/public/info'
@@ -1188,7 +1188,7 @@ class PoloniexAuxiliary(Enum):
 
 class LbankAuxiliary(Enum):
     url = "https://api.lbkex.com"
-    swap_url = "https://api.lbkex.com"
+    perp_url = "https://api.lbkex.com"
     url_ticker = "/v2/ticker/24hr.do"
     url_ticker_price = '/v2/supplement/ticker/price.do'
     url_exchange = "/v2/currencyPairs.do"

--- a/pytradekit/utils/mongodb_operations.py
+++ b/pytradekit/utils/mongodb_operations.py
@@ -414,7 +414,7 @@ class MongodbOperations:
                                          collection_name=Database.run_task.name)
         self.insert_data(data, collection_path)
 
-    def insert_swap_position_risk(self, data):
+    def insert_perp_position_risk(self, data):
         collection_path = CollectionPath(db_name=Database.raw_accounts.name,
                                          collection_name=Database.perp_position.name)
         self.insert_data(data, collection_path)
@@ -749,7 +749,7 @@ class MongodbOperations:
         else:
             return res
 
-    def read_swap_position_risk(self, inst_code, account_id, time_span=None, limit=1):
+    def read_perp_position_risk(self, inst_code, account_id, time_span=None, limit=1):
         params = {}
         if inst_code:
             params[PerpPositionAttribute.inst_code.name] = inst_code
@@ -765,7 +765,7 @@ class MongodbOperations:
             -1).limit(limit)
         res = list(res)
         if len(res) == 0:
-            raise NoDataException(f'No swap position found for inst_code {inst_code}')
+            raise NoDataException(f'No perp position found for inst_code {inst_code}')
         return res
 
     def read_perp_income(self, account_id, inst_code, since_ms: int = None):

--- a/pytradekit/utils/static_types.py
+++ b/pytradekit/utils/static_types.py
@@ -1256,6 +1256,3 @@ class FundingRateHistory:
         return {slot: getattr(self, slot) for slot in self.__slots__}
 
 
-# Aliases for backward compatibility with liquidity_monitor
-SwapPosition = PerpPosition
-SwapIncome = PerpIncome

--- a/pytradekit/ws/binance_ws.py
+++ b/pytradekit/ws/binance_ws.py
@@ -22,7 +22,7 @@ class BinanceWsManager(WsManager):
 
     def __init__(self, logger, config=None, running_mode=None, queue=None, api_key=None, api_secret=None,
                  strategy_id=None, portfolio_id=None,
-                 account_id=None, url=BinanceAuxiliary.url_ws.value, api_url=BinanceAuxiliary.url.value, is_swap=False,
+                 account_id=None, url=BinanceAuxiliary.url_ws.value, api_url=BinanceAuxiliary.url.value, is_perp=False,
                  ticker_queue=None, kline_queue=None, start_end_time_dict=None,
                  send_params=None, is_supplement=False, bn_client=None, mm_symbol_list=None):
         super().__init__(api_key, logger, start_end_time_dict)
@@ -30,7 +30,7 @@ class BinanceWsManager(WsManager):
         self.config = config
         self.running_mode = running_mode
         self._api_url = api_url
-        if is_swap:
+        if is_perp:
             self._url = BinanceAuxiliary.url_perp_ws.value
         else:
             self._url = url
@@ -43,8 +43,8 @@ class BinanceWsManager(WsManager):
         self._account_id = account_id
         self._ws_connected = False
         self._kline_queue = kline_queue
-        if is_swap:
-            self._listen_key_url = BinanceAuxiliary.perp_url.value + BinanceAuxiliary.user_swap_data_stream.value
+        if is_perp:
+            self._listen_key_url = BinanceAuxiliary.perp_url.value + BinanceAuxiliary.user_perp_data_stream.value
         else:
             self._listen_key_url = self._get_api_url() + BinanceAuxiliary.user_data_stream.value
         self.start_end_time_dict = start_end_time_dict
@@ -234,7 +234,7 @@ class BinanceWsManager(WsManager):
         self.start_subscribe(params)
         self._ping(BinanceAuxiliary.ws_ping_sleep.value, is_listen_key=False)
 
-    def start_swap_lastprice_stream(self, symbols):
+    def start_perp_lastprice_stream(self, symbols):
         params = []
         for symbol in symbols:
             params.append(f'{symbol.lower()}{BinanceAuxiliary.ws_lastprice.value}')

--- a/pytradekit/ws/new_binance_ws.py
+++ b/pytradekit/ws/new_binance_ws.py
@@ -19,7 +19,7 @@ class BinanceWsManager:
     _listen_key = {}
 
     def __init__(self, logger, queue=None, api_key=None, strategy_id=None, portfolio_id=None, account_id=None,
-                 url=BinanceAuxiliary.url_ws.value, api_url=BinanceAuxiliary.url.value, is_swap=False,
+                 url=BinanceAuxiliary.url_ws.value, api_url=BinanceAuxiliary.url.value, is_perp=False,
                  ticker_queue=None):
         self._api_url = api_url
         self._url = url
@@ -35,8 +35,8 @@ class BinanceWsManager:
         self._msg = []
         self.status = WebsocketStatus.INIT.name
         self.ws = None
-        if is_swap:
-            self._listen_key_url = BinanceAuxiliary.perp_url.value + BinanceAuxiliary.user_swap_data_stream.value
+        if is_perp:
+            self._listen_key_url = BinanceAuxiliary.perp_url.value + BinanceAuxiliary.user_perp_data_stream.value
         else:
             self._listen_key_url = self._get_api_url() + BinanceAuxiliary.user_data_stream.value
 


### PR DESCRIPTION
## Summary
- Rename all `swap` identifiers to `perp` across all 16 exchange REST clients, WebSocket handlers, MongoDB operations, and type definitions — aligns terminology with perpetual futures industry convention
- Fix Binance ticker WebSocket: `!ticker@arr` was silently deprecated by Binance; switch to `!miniTicker@arr` which has compatible field structure (`s`/`c` for symbol/price)
- Remove backward-compat `SwapPosition`/`SwapIncome` aliases from `static_types.py`

## Key renames
| Old | New |
|-----|-----|
| `BinanceSwapClient` | `BinancePerpClient` |
| `get_swap_*` | `get_perp_*` |
| `is_swap` | `is_perp` |
| `insert_swap_position_risk` | `insert_perp_position_risk` |
| `ws_ticker = "!ticker@arr"` | `ws_ticker = "!miniTicker@arr"` |

## Test plan
- [ ] Run `docker run --rm -v $(pwd):/app -w /app python:3.11 bash -c "pip install -r requirements.txt -q && python -m pytest"`
- [ ] Verify BN ticker prices appear in Redis after deploying `fetch_bn_ws_ticker_price`
- [ ] Confirm all downstream projects updated to use new method names (see companion PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)