### PR TITLE
fix: set_portfolios 无法序列化 Decimal 导致 portfolio 信号全部丢失

### DIFF
--- a/pytradekit/utils/redis_operations.py
+++ b/pytradekit/utils/redis_operations.py
@@ -6,6 +6,13 @@ from pytradekit.utils.dynamic_types import RedisFields
 from pytradekit.utils.time_handler import TimeConvert
 from pytradekit.utils.exceptions import DependencyException
 
+
+class _DecimalEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, Decimal):
+            return str(obj)
+        return super().default(obj)
+
 TICKER_PRICE_EXPIRE_TIME = TimeConvert.MIN_TO_S * 10
 ORDER_TICKER_EXPIRE_TIME = TimeConvert.MIN_TO_S * 30
 ORDERS_EXPIRE_TIME = TimeConvert.MIN_TO_S * 60
@@ -280,8 +287,9 @@ class RedisOperations:
         lock = self.get_lock_for_resource(key)
         try:
             with lock:
-                self.client.set(key, json.dumps(value))
-                self.client.publish(key, json.dumps(value))
+                serialized = json.dumps(value, cls=_DecimalEncoder)
+                self.client.set(key, serialized)
+                self.client.publish(key, serialized)
         except Exception as e:
             self.logger.exception(f"Failed to set portfolios for {key}: {e}")
             raise DependencyException(f"Failed to set portfolios for {key}") from e

--- a/pytradekit/utils/redis_operations.py
+++ b/pytradekit/utils/redis_operations.py
@@ -13,6 +13,7 @@ class _DecimalEncoder(json.JSONEncoder):
             return str(obj)
         return super().default(obj)
 
+
 TICKER_PRICE_EXPIRE_TIME = TimeConvert.MIN_TO_S * 10
 ORDER_TICKER_EXPIRE_TIME = TimeConvert.MIN_TO_S * 30
 ORDERS_EXPIRE_TIME = TimeConvert.MIN_TO_S * 60


### PR DESCRIPTION
## 1. 本次 PR 的目的（What & Why）

- **修复**：`set_portfolios` 调用 `json.dumps` 时，portfolio 数据中包含 `Decimal` 字段，导致 `TypeError: Object of type Decimal is not JSON serializable`，每次触发均抛异常被吞，Redis 信号从未发布
- **原因**：2026-04-24 SPKUSDT@HTX 全天多次达到 premium 阈值（0.5%~1.33%），但因序列化异常，`portfolios` 频道始终无消息，`arbitrage_executor` 全天收到 0 个信号，错过所有交易机会

## 2. 主要修改内容（Changes）

**`pytradekit/utils/redis_operations.py`**
- 新增 `_DecimalEncoder(json.JSONEncoder)`，将 `Decimal` 转为字符串
- `set_portfolios` 改用 `json.dumps(value, cls=_DecimalEncoder)`，同一份序列化结果同时写 `set` 和 `publish`（消除原来两次重复序列化）

## 3. 是否影响以下关键功能？（Impact Check）

| 功能 | 影响 |
|------|------|
| 交易执行逻辑 | **是**（这是信号链路的关键修复，修复后 arbitrage_executor 才能收到 portfolio 信号） |
| 风控逻辑 | 否 |
| 交易池确定逻辑 | 否 |

## 4. 数据一致性

- `Decimal` → `str` 序列化，精度完整保留，接收方 `arbitrage_executor` 在反序列化后需注意将字符串还原为 `Decimal`（原流程已有此处理）

## 5. 测试（Testing）

**本地测试：**
- [x] 复现错误：构造含 `Decimal` 的 dict 传入 `json.dumps` → 抛异常
- [x] 验证修复：使用 `json.dumps(value, cls=_DecimalEncoder)` → 正常序列化
- [ ] 单元测试待补充

**根因日志证据：**
```
redis_operations.py:286 ERROR: Failed to set portfolios for portfolios: Object of type Decimal is not JSON serializable
realtime_compute_premium.py:162 ERROR: Failed to set portfolios for SPKUSDT@HTX: dependency is not work well
```
从 08:46 到 11:36 共 16 次触发，全部失败。

## 6. 风险评估（Risk Assessment）

- **低风险**：仅改序列化方式，`Decimal` → `str` 精度无损，接收方行为不变
- 顺带消除了原来 `set` 和 `publish` 两次重复 `json.dumps` 调用

## 7. 额外信息（Optional）

昨日（2026-04-24）错失交易机会统计：
- SPKUSDT@HTX 触发 16 次，premium 最高达 **1.33%**（11:26）
- arbitrage_executor 全天 "no portfolio signal"，无任何交易被执行

## 8. Reviewer Checklist（供 reviewer 使用）

- [ ] 确认 `arbitrage_executor` 接收 portfolio 消息后对字符串 premium 的处理兼容
- [ ] 确认其他调用 `json.dumps` 的方法是否存在同样的 Decimal 问题
- [ ] 部署后观察 `realtime_compute_premium.log` 中 `threshold_count` 是否正常递增