### PR TITLE
fix: Ed25519 签名改用 UTF-8，修复非 ASCII symbol 触发 UnicodeEncodeError

### DIFF
--- a/pytradekit/restful/binance_restful.py
+++ b/pytradekit/restful/binance_restful.py
@@ -151,7 +151,7 @@ class BinanceClient:
             private_key_bytes = base64.b64decode(self.secret_key)
             signing_key = SigningKey(private_key_bytes)
 
-            signed = signing_key.sign(query_string.encode("ASCII")).signature
+            signed = signing_key.sign(query_string.encode("UTF-8")).signature
             signature_b64 = base64.b64encode(signed).decode("ASCII")
             return signature_b64
         except Exception as e:


### PR DESCRIPTION
## 1. 本次 PR 的目的（What & Why）

- **修复**：`_hashing()` 中 `query_string.encode("ASCII")` 改为 `encode("UTF-8")`
- **原因**：Binance 合约偶发含中文字符的 symbol（如 `币安人生USDT`），进入签名流程时触发 `UnicodeEncodeError`，以 ERROR 级别写日志并抛出 `ExchangeException`。调用方已有 fallback（降级静态费率），但每日持续产生 ERROR 噪音。

---

## 2. 主要修改内容（Changes）

**`pytradekit/restful/binance_restful.py` L154**

```python
# before
signed = signing_key.sign(query_string.encode("ASCII")).signature
# after
signed = signing_key.sign(query_string.encode("UTF-8")).signature
```

Ed25519 签名本身对字节内容无 ASCII 限制；Binance 服务端对非 ASCII symbol 同样会拒绝，但此时错误会被正常的 `ExchangeException` 路径捕获，不再以 `UnicodeEncodeError` 形式打 ERROR 日志。

---

## 3. 是否影响以下关键功能？（Impact Check）

- **交易执行逻辑**：不涉及
- **风控逻辑**：不涉及
- **交易池确定逻辑**：不涉及

---

## 4. 数据一致性

对正常 ASCII symbol 行为无变化；非 ASCII symbol 的签名字节会不同，但这些 symbol 本身就是无效的 Binance 交易对，API 无论如何会拒绝。

---

## 5. 测试（Testing）

- [ ] 正常 ASCII symbol 签名路径回归验证
- [ ] 含中文字符的 symbol 不再抛 `UnicodeEncodeError`，正常走 `ExchangeException` fallback

---

## 6. 风险评估（Risk Assessment）

**极低**：仅改变编码方式，对所有合法 ASCII symbol 签名字节不变。

---

## 8. Reviewer Checklist

- [ ] L154 编码由 ASCII → UTF-8，L155 的 `decode("ASCII")` 无需改动（base64 输出恒为 ASCII）