### PR TITLE
fix(redis): get_target_premium 兼容 decode_responses=True 返回的 str

### DIFF
--- a/pytradekit/utils/redis_operations.py
+++ b/pytradekit/utils/redis_operations.py
@@ -335,7 +335,12 @@ class RedisOperations:
         lock = self.get_lock_for_resource(key)
         try:
             with lock:
-                return Decimal(self.client.get(key).decode())
+                value = self.client.get(key)
+                if value is None:
+                    return None
+                if isinstance(value, bytes):
+                    value = value.decode()
+                return Decimal(value)
         except Exception as e:
             self.logger.exception(f"Failed to get target premium for {order_id}: {e}")
             raise DependencyException(f"Failed to get target premium for {order_id}") from e

--- a/tests/test_redis_operations.py
+++ b/tests/test_redis_operations.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 import pytest
 from unittest.mock import MagicMock
 from pytradekit.utils.redis_operations import RedisOperations
@@ -95,3 +97,27 @@ class TestClose:
         with pytest.raises(DependencyException) as exc_info:
             ops.close()
         assert exc_info.value.__cause__ is original
+
+
+class TestGetTargetPremium:
+    def test_returns_decimal_from_str_value(self, redis_ops):
+        # decode_responses=True 时返回 str，不应再调用 .decode()
+        ops, client, _ = redis_ops
+        client.get.return_value = "0.0123"
+        assert ops.get_target_premium("perp_sell_x") == Decimal("0.0123")
+
+    def test_returns_decimal_from_bytes_value(self, redis_ops):
+        ops, client, _ = redis_ops
+        client.get.return_value = b"0.0456"
+        assert ops.get_target_premium("perp_sell_x") == Decimal("0.0456")
+
+    def test_returns_none_when_key_missing(self, redis_ops):
+        ops, client, _ = redis_ops
+        client.get.return_value = None
+        assert ops.get_target_premium("perp_sell_x") is None
+
+    def test_client_failure_raises_dependency_exception(self, redis_ops):
+        ops, client, _ = redis_ops
+        client.get.side_effect = Exception("redis down")
+        with pytest.raises(DependencyException):
+            ops.get_target_premium("perp_sell_x")


### PR DESCRIPTION
## 背景
线上 monitor_trading_record 在处理 perp 成交回报时持续报错：

\`\`\`
[redis_operations.py:340] ERROR: Failed to get target premium for perp_sell_xxx:
  'str' object has no attribute 'decode'
\`\`\`

根因：\`RedisOperations\` 构造时使用 \`decode_responses=True\`（line 27），\`client.get\` 返回 \`str\`，但 \`get_target_premium\` 仍直接调用 \`.decode()\` 导致 \`AttributeError\`。

该异常打断了 \`monitor_trading_record._handle_perp_trade\` 的后续流程 —— 短腿（SHORT_LEG）没构建出来，trade record 的 \`status\` 也没被设成 \`open\`，连带让 \`close_executor.read_trade_records(status="open")\` 永远查到 0 条，最终导致**实际有持仓但平仓器看不到**。

CEA 上目前因此积压了 MONUSDT/SKYAIUSDT 两笔孤儿空单（合计名义 ~3535 USDT），占住 perp 保证金，使 SKYAIUSDT premium 多次达标的信号全部因可用余额不足被 skip。

## 改动
- \`get_target_premium\` 与同文件 \`get_order_link\` 对齐：先判断 \`isinstance(value, bytes)\` 再决定是否 decode；并在 \`value is None\` 时直接返回 \`None\`（调用方 \`monitor_trading_record.py:509-514\` 已能处理 None）。
- 加 4 个单测覆盖 str / bytes / None / 客户端异常四条路径。

## Test plan
- [x] \`pytest tests/test_redis_operations.py\` 全绿（16 passed）
- [ ] 灰度后验证 monitor_trading_record 不再打印 \`'str' object has no attribute 'decode'\`
- [ ] 验证后续新开的 trade 在 MongoDB 里能写入完整 SHORT_LEG 且 status=open

🤖 Generated with [Claude Code](https://claude.com/claude-code)