### PR TITLE
fix(huobi_ws): 私有 WS 断线重连先 re-auth

### DIFF
--- a/pytradekit/ws/huobi_ws.py
+++ b/pytradekit/ws/huobi_ws.py
@@ -141,6 +141,22 @@ class HuobiWsManager(WsManager):
         _rqs = {'action': 'req', 'ch': 'auth', 'params': params}
         self.start_subscribe(_rqs)
 
+    def _reconnect_streams(self):
+        """断线重连后的恢复钩子。
+
+        私有 WS（is_public=False）必须先重新 auth；旧实现直接走 base 层的
+        _reconnect_streams 把 _subs 里的 trade.clearing#*#0 在未登录状态下重发，
+        HTX 立刻回 code=2002 invalid.auth.state，订阅在下次 subscribe() 主循环
+        触发 _login（默认 3 小时）前永远是失效的。
+
+        修复：私有连接重连后只发 auth，订阅交给 _on_message 收到 auth 成功
+        回调时再补发（已有的 _send_trade 行为）。
+        """
+        if not self.is_public:
+            self._login()
+        else:
+            super()._reconnect_streams()
+
     def start_subscribe(self, params):
         try:
             self.send_json(params)

--- a/tests/test_huobi_ws.py
+++ b/tests/test_huobi_ws.py
@@ -1,0 +1,51 @@
+"""HuobiWsManager 重连流程测试。
+
+主要验证 #51 / #52 之后的 _reconnect_streams 行为：
+- 公开 WS（is_public=True）保留旧逻辑，重发 _subs；
+- 私有 WS（is_public=False）必须先 _login，订阅由 auth 成功回调再发，
+  避免 invalid.auth.state。
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_manager(is_public, mocker):
+    """构造一个 HuobiWsManager 实例，跳过底层 WS 连接。"""
+    with patch('pytradekit.ws.huobi_ws.WsManager.__init__', return_value=None):
+        from pytradekit.ws.huobi_ws import HuobiWsManager
+        mgr = HuobiWsManager.__new__(HuobiWsManager)
+        # 手填必要属性，覆盖 super().__init__() 没执行的部分
+        mgr.is_public = is_public
+        mgr.logger = MagicMock()
+        mgr._subs = [{'action': 'sub', 'ch': 'trade.clearing#*#0'}]
+        mgr._api_key = 'key'
+        mgr._api_secret = 'secret'
+        mgr.send_json = MagicMock()
+        # WsManager.send_json 在父类里，避免被它访问 _cur_id
+        return mgr
+
+
+class TestReconnectStreams:
+    def test_private_ws_relogins_instead_of_resending_subs(self, mocker):
+        mgr = _make_manager(is_public=False, mocker=mocker)
+        mocker.patch.object(mgr, '_login')
+        mocker.patch('pytradekit.gateway.websocket.base_ws_manager.BaseWebsocketManager._reconnect_streams')
+
+        mgr._reconnect_streams()
+
+        # 私有连接：只调 _login，不走父类的 _reconnect_streams
+        mgr._login.assert_called_once()
+
+    def test_public_ws_delegates_to_super(self, mocker):
+        mgr = _make_manager(is_public=True, mocker=mocker)
+        mocker.patch.object(mgr, '_login')
+        super_mock = mocker.patch(
+            'pytradekit.gateway.websocket.ws_manager.WsManager._reconnect_streams'
+        )
+
+        mgr._reconnect_streams()
+
+        # 公开行情：不应触发 _login；走父类重发订阅
+        mgr._login.assert_not_called()
+        super_mock.assert_called_once()


### PR DESCRIPTION
## 背景
线上 monitor_trading_record 日志从 2026-05-06 00:29 起持续刷 \`invalid.auth.state\`：

\`\`\`
[huobi_ws.py:187] INFO: huobi ws subscribe failed:
  ch=trade.clearing#*#0, code=2002, msg=invalid.auth.state
\`\`\`

5-06 至今累计 **4244 次失败 vs 仅 75 次成功**。HTX 上的现货成交事件几乎全丢，monitor 收不到 spot trade 流，trade_records 中 LONG_LEG 写不上、SHORT_LEG 也补不齐，连锁导致 close_executor 看不到 5-08 那 15 笔 MON 单的存在。

## 根因
\`HuobiWsManager.subscribe()\` 初连成功走 \`_login()\` → \`_on_message\` 收到 \`code=200\` → \`_send_trade\` 订阅 \`trade.clearing#*#0\` → 加入 \`self._subs\`。

WS 断开后：
- base 层 \`_recovery\` 重连，调 \`self._reconnect_streams()\`；
- 父类实现是直接重发 \`_subs\` 里的所有 sub 请求，**没有先 _login**；
- HTX 在未登录状态收到订阅 → 回 \`code=2002 invalid.auth.state\`；
- subscribe() 主循环里的周期性 \`_login\` 周期是 \`reconnection_time_sleep = 60 * 60 * 3 = 3 小时\`；
- 中间这段时间里 HTX 私有 WS 是"连接 OK 但未登录"的僵尸状态，所有订阅都会失败。

## 改动
覆写 \`HuobiWsManager._reconnect_streams\`：

- \`is_public=False\`：只调 \`_login()\`，订阅交给 \`_on_message\` 收到 \`code=200\` 时的 \`_send_trade\` 重发（已有逻辑）；
- \`is_public=True\`：保留父类行为，重发 \`_subs\`。

## Test plan
- [x] \`pytest tests/test_huobi_ws.py\` 新增 2 个测试：私有连接重连只发 _login；公开连接重连走父类。
- [ ] 灰度后观察 monitor_trading_record.log 中 \`invalid.auth.state\` 不再持续刷，HTX trade.clearing#*#0 在重连后能正常 \`subscribed\`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)