### PR TITLE
chore(tests): 删除 test_redis_operations 中未使用的 MagicMock 导入

### DIFF
--- a/tests/test_redis_operations.py
+++ b/tests/test_redis_operations.py
@@ -1,7 +1,6 @@
 from decimal import Decimal
 
 import pytest
-from unittest.mock import MagicMock
 from pytradekit.utils.redis_operations import RedisOperations
 from pytradekit.utils.exceptions import DependencyException
 


### PR DESCRIPTION
## Summary
- 修复 code review 指出的未使用导入：`tests/test_redis_operations.py:3` 的 `from unittest.mock import MagicMock`
- fixture 内已通过 `mocker.MagicMock()` 创建 mock 对象，顶部直接导入的 `MagicMock` 全文件未引用

## Test plan
- [x] `pytest tests/test_redis_operations.py` 16 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)