### PR TITLE
fix(redis_operations): 移除 get_target_premium 死代码并补齐异常测试

### DIFF
--- a/pytradekit/utils/redis_operations.py
+++ b/pytradekit/utils/redis_operations.py
@@ -338,8 +338,6 @@ class RedisOperations:
                 value = self.client.get(key)
                 if value is None:
                     return None
-                if isinstance(value, bytes):
-                    value = value.decode()
                 return Decimal(value)
         except Exception as e:
             self.logger.exception(f"Failed to get target premium for {order_id}: {e}")

--- a/tests/test_redis_operations.py
+++ b/tests/test_redis_operations.py
@@ -100,15 +100,9 @@ class TestClose:
 
 class TestGetTargetPremium:
     def test_returns_decimal_from_str_value(self, redis_ops):
-        # decode_responses=True 时返回 str，不应再调用 .decode()
         ops, client, _ = redis_ops
         client.get.return_value = "0.0123"
         assert ops.get_target_premium("perp_sell_x") == Decimal("0.0123")
-
-    def test_returns_decimal_from_bytes_value(self, redis_ops):
-        ops, client, _ = redis_ops
-        client.get.return_value = b"0.0456"
-        assert ops.get_target_premium("perp_sell_x") == Decimal("0.0456")
 
     def test_returns_none_when_key_missing(self, redis_ops):
         ops, client, _ = redis_ops
@@ -120,3 +114,18 @@ class TestGetTargetPremium:
         client.get.side_effect = Exception("redis down")
         with pytest.raises(DependencyException):
             ops.get_target_premium("perp_sell_x")
+
+    def test_client_failure_logs_exception(self, redis_ops):
+        ops, client, logger = redis_ops
+        client.get.side_effect = Exception("redis down")
+        with pytest.raises(DependencyException):
+            ops.get_target_premium("perp_sell_x")
+        logger.exception.assert_called_once()
+
+    def test_client_failure_chains_original_exception(self, redis_ops):
+        ops, client, _ = redis_ops
+        original = Exception("redis down")
+        client.get.side_effect = original
+        with pytest.raises(DependencyException) as exc_info:
+            ops.get_target_premium("perp_sell_x")
+        assert exc_info.value.__cause__ is original


### PR DESCRIPTION
## Summary
- `RedisOperations.__init__` 用 `decode_responses=True` 初始化 client，`client.get()` 始终返回 `str`/`None`，因此 `get_target_premium` 中的 `isinstance(value, bytes)` 分支不可达——删除该分支及对应的 `test_returns_decimal_from_bytes_value` 测试。
- 给 `TestGetTargetPremium` 补齐 `test_client_failure_logs_exception` 和 `test_client_failure_chains_original_exception`，与 `TestPing` / `TestClose` / `TestCreatePubsub` 三测试一组的失败场景模式保持一致。

## Test plan
- [x] `pytest tests/test_redis_operations.py -v`（17 passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)