### PR TITLE
fix(redis_operations): 处理非法 Decimal 并消除测试 DRY 违规

### DIFF
--- a/pytradekit/utils/redis_operations.py
+++ b/pytradekit/utils/redis_operations.py
@@ -1,10 +1,10 @@
 import json
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 
 import redis
 from pytradekit.utils.dynamic_types import RedisFields
 from pytradekit.utils.time_handler import TimeConvert
-from pytradekit.utils.exceptions import DependencyException
+from pytradekit.utils.exceptions import DataTypeException, DependencyException
 
 
 class _DecimalEncoder(json.JSONEncoder):
@@ -336,12 +336,17 @@ class RedisOperations:
         try:
             with lock:
                 value = self.client.get(key)
-                if value is None:
-                    return None
-                return Decimal(value)
         except Exception as e:
             self.logger.exception(f"Failed to get target premium for {order_id}: {e}")
             raise DependencyException(f"Failed to get target premium for {order_id}") from e
+
+        if value is None:
+            return None
+        try:
+            return Decimal(value)
+        except InvalidOperation as e:
+            self.logger.exception(f"Invalid premium value for {order_id}: {value!r}")
+            raise DataTypeException(f"Invalid premium value for {order_id}: {value!r}") from e
 
     def ping(self):
         """Verify the Redis connection is alive. Raises DependencyException on failure."""

--- a/tests/test_redis_operations.py
+++ b/tests/test_redis_operations.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 
 import pytest
 from pytradekit.utils.redis_operations import RedisOperations
-from pytradekit.utils.exceptions import DependencyException
+from pytradekit.utils.exceptions import DataTypeException, DependencyException
 
 
 @pytest.fixture
@@ -14,88 +14,49 @@ def redis_ops(mocker):
     return ops, mock_client, mock_logger
 
 
+def assert_wraps_as_dependency_exception(redis_ops, client_attr, op_name, *args):
+    """Assert ops.<op_name>(*args) wraps a client error as DependencyException.
+
+    Covers all three failure behaviors in one call:
+    raises DependencyException, chains __cause__, calls logger.exception once.
+    """
+    ops, client, logger = redis_ops
+    original = Exception("boom")
+    getattr(client, client_attr).side_effect = original
+    with pytest.raises(DependencyException) as exc_info:
+        getattr(ops, op_name)(*args)
+    assert exc_info.value.__cause__ is original
+    logger.exception.assert_called_once()
+
+
 class TestPing:
-    def test_ping_success_delegates_to_client(self, redis_ops):
+    def test_success_delegates_to_client(self, redis_ops):
         ops, client, _ = redis_ops
         ops.ping()
         client.ping.assert_called_once()
 
-    def test_ping_failure_raises_dependency_exception(self, redis_ops):
-        ops, client, _ = redis_ops
-        client.ping.side_effect = Exception("connection refused")
-        with pytest.raises(DependencyException):
-            ops.ping()
-
-    def test_ping_failure_logs_exception(self, redis_ops):
-        ops, client, logger = redis_ops
-        client.ping.side_effect = Exception("connection refused")
-        with pytest.raises(DependencyException):
-            ops.ping()
-        logger.exception.assert_called_once()
-
-    def test_ping_failure_chains_original_exception(self, redis_ops):
-        ops, client, _ = redis_ops
-        original = Exception("connection refused")
-        client.ping.side_effect = original
-        with pytest.raises(DependencyException) as exc_info:
-            ops.ping()
-        assert exc_info.value.__cause__ is original
+    def test_failure_wraps_as_dependency_exception(self, redis_ops):
+        assert_wraps_as_dependency_exception(redis_ops, "ping", "ping")
 
 
 class TestCreatePubsub:
-    def test_create_pubsub_returns_client_pubsub(self, redis_ops):
+    def test_returns_client_pubsub(self, redis_ops):
         ops, client, _ = redis_ops
         result = ops.create_pubsub()
         assert result is client.pubsub.return_value
 
-    def test_create_pubsub_failure_raises_dependency_exception(self, redis_ops):
-        ops, client, _ = redis_ops
-        client.pubsub.side_effect = Exception("pubsub error")
-        with pytest.raises(DependencyException):
-            ops.create_pubsub()
-
-    def test_create_pubsub_failure_logs_exception(self, redis_ops):
-        ops, client, logger = redis_ops
-        client.pubsub.side_effect = Exception("pubsub error")
-        with pytest.raises(DependencyException):
-            ops.create_pubsub()
-        logger.exception.assert_called_once()
-
-    def test_create_pubsub_failure_chains_original_exception(self, redis_ops):
-        ops, client, _ = redis_ops
-        original = Exception("pubsub error")
-        client.pubsub.side_effect = original
-        with pytest.raises(DependencyException) as exc_info:
-            ops.create_pubsub()
-        assert exc_info.value.__cause__ is original
+    def test_failure_wraps_as_dependency_exception(self, redis_ops):
+        assert_wraps_as_dependency_exception(redis_ops, "pubsub", "create_pubsub")
 
 
 class TestClose:
-    def test_close_success_delegates_to_client(self, redis_ops):
+    def test_success_delegates_to_client(self, redis_ops):
         ops, client, _ = redis_ops
         ops.close()
         client.close.assert_called_once()
 
-    def test_close_failure_raises_dependency_exception(self, redis_ops):
-        ops, client, _ = redis_ops
-        client.close.side_effect = Exception("close failed")
-        with pytest.raises(DependencyException):
-            ops.close()
-
-    def test_close_failure_logs_exception(self, redis_ops):
-        ops, client, logger = redis_ops
-        client.close.side_effect = Exception("close failed")
-        with pytest.raises(DependencyException):
-            ops.close()
-        logger.exception.assert_called_once()
-
-    def test_close_failure_chains_original_exception(self, redis_ops):
-        ops, client, _ = redis_ops
-        original = Exception("close failed")
-        client.close.side_effect = original
-        with pytest.raises(DependencyException) as exc_info:
-            ops.close()
-        assert exc_info.value.__cause__ is original
+    def test_failure_wraps_as_dependency_exception(self, redis_ops):
+        assert_wraps_as_dependency_exception(redis_ops, "close", "close")
 
 
 class TestGetTargetPremium:
@@ -103,29 +64,25 @@ class TestGetTargetPremium:
         ops, client, _ = redis_ops
         client.get.return_value = "0.0123"
         assert ops.get_target_premium("perp_sell_x") == Decimal("0.0123")
+        client.get.assert_called_once_with("premium:perp_sell_x")
 
     def test_returns_none_when_key_missing(self, redis_ops):
         ops, client, _ = redis_ops
         client.get.return_value = None
         assert ops.get_target_premium("perp_sell_x") is None
+        client.get.assert_called_once_with("premium:perp_sell_x")
 
-    def test_client_failure_raises_dependency_exception(self, redis_ops):
+    def test_invalid_decimal_string_raises_data_type_exception(self, redis_ops):
         ops, client, _ = redis_ops
-        client.get.side_effect = Exception("redis down")
-        with pytest.raises(DependencyException):
+        client.get.return_value = "not-a-number"
+        with pytest.raises(DataTypeException):
             ops.get_target_premium("perp_sell_x")
 
-    def test_client_failure_logs_exception(self, redis_ops):
-        ops, client, logger = redis_ops
-        client.get.side_effect = Exception("redis down")
-        with pytest.raises(DependencyException):
-            ops.get_target_premium("perp_sell_x")
-        logger.exception.assert_called_once()
-
-    def test_client_failure_chains_original_exception(self, redis_ops):
+    def test_empty_string_raises_data_type_exception(self, redis_ops):
         ops, client, _ = redis_ops
-        original = Exception("redis down")
-        client.get.side_effect = original
-        with pytest.raises(DependencyException) as exc_info:
+        client.get.return_value = ""
+        with pytest.raises(DataTypeException):
             ops.get_target_premium("perp_sell_x")
-        assert exc_info.value.__cause__ is original
+
+    def test_failure_wraps_as_dependency_exception(self, redis_ops):
+        assert_wraps_as_dependency_exception(redis_ops, "get", "get_target_premium", "perp_sell_x")


### PR DESCRIPTION
## Summary
针对昨日 code review 反馈的 4 个问题：

- **实现 + 测试**：`get_target_premium` 现在捕获 `Decimal(value)` 抛出的 `InvalidOperation`，转为 `DataTypeException`，覆盖 Redis 中误存非法字符串 / 空串的边界场景；新增 `test_invalid_decimal_string_raises_data_type_exception` 与 `test_empty_string_raises_data_type_exception`。
- **测试**：`test_returns_decimal_from_str_value` / `test_returns_none_when_key_missing` 补充 `client.get.assert_called_once_with("premium:perp_sell_x")` 断言，验证 key 拼接格式 `{field}:{identifier}` 符合规范。
- **测试 DRY**：提取 `assert_wraps_as_dependency_exception` 辅助函数，统一覆盖 raises / __cause__ / logger.exception 三项，将 `TestPing` / `TestCreatePubsub` / `TestClose` / `TestGetTargetPremium` 共 12 个三段式失败用例合并为 4 个等价单测。

## Test plan
- [x] `pytest tests/test_redis_operations.py -v` — 11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)