### PR TITLE
fix: update_trade_record Decimal 编码 + binance_ws perp 事件 DEBUG 日志

### DIFF
--- a/pytradekit/utils/mongodb_operations.py
+++ b/pytradekit/utils/mongodb_operations.py
@@ -1407,7 +1407,10 @@ class MongodbOperations:
 
     def update_trade_record(self, trade_id, update_data):
         params = {TradeRecordAttribute.trade_id.name: trade_id}
-        update = {'$set': update_data}
+        # Strip Decimal → str via get_correct_dict; pymongo's BSON encoder rejects raw Decimal
+        # (only Decimal128). insert_data already routes through get_correct_dict; this kept the
+        # asymmetry which made subsequent updates silently fail with `cannot encode object: Decimal`.
+        update = {'$set': self.get_correct_dict(update_data)}
         self.client[Database.arbitrage.name][Database.trade_records.name].update_one(params, update)
 
     def read_trade_records(self, status=None, strategy_type=None, strategy_id=None, coin=None,

--- a/pytradekit/ws/binance_ws.py
+++ b/pytradekit/ws/binance_ws.py
@@ -318,6 +318,15 @@ class BinanceWsManager(WsManager):
                 self._pong()
             else:
                 if self.verify_perp_order_trade(msg):
+                    # DEBUG per-event log — leave at DEBUG so it's off by default but available
+                    # for post-mortem when a perp order's WS event appears to be missing.
+                    o = msg.get(BinanceWebSocket.perp_order_data.value, {}) or {}
+                    self.logger.debug(
+                        f"perp ORDER_TRADE_UPDATE: symbol={o.get(BinanceWebSocket.symbol.value)} "
+                        f"clientOrderId={o.get(BinanceWebSocket.client_order_id_new.value)} "
+                        f"status={o.get(BinanceWebSocket.status.value)} "
+                        f"side={o.get(BinanceWebSocket.side.value)}"
+                    )
                     self._queue.put_nowait(msg)
                     return
                 if self.verify_spot_order_trade(msg):

--- a/tests/test_mongodb_operations.py
+++ b/tests/test_mongodb_operations.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from pytradekit.utils.mongodb_operations import MongodbOperations
 
 
@@ -45,3 +47,54 @@ def test_check_connection(mocker):
     mocked_admin.command.assert_called_once_with('ping')
     # 验证返回值是否为True，即连接正常
     assert connection_status is True
+
+
+class TestUpdateTradeRecordStripsDecimal:
+    """update_trade_record was previously skipping get_correct_dict; raw Decimal in the
+    payload caused pymongo to raise `cannot encode object: Decimal(...)` and the update
+    failed silently. This guards the symmetric conversion with insert_data."""
+
+    def _make_ops(self, mocker):
+        MongodbOperations._client = None
+        MongodbOperations._indexes_ensured = False
+        mocked_client = mocker.MagicMock()
+        mocker.patch('pytradekit.utils.mongodb_operations.MongoClient', return_value=mocked_client)
+        mocker.patch.object(MongodbOperations, '_ensure_indexes')
+        ops = MongodbOperations("mongodb://x:y@localhost:27017")
+        return ops, mocked_client
+
+    def test_decimal_fields_converted_to_str(self, mocker):
+        ops, mocked_client = self._make_ops(mocker)
+        update_data = {
+            'legs': {
+                'SHORT_LEG': {'fee': Decimal('0.00057500'), 'entry_price': Decimal('523.17')},
+            },
+            'status': 'open',
+        }
+        ops.update_trade_record('trade_xyz', update_data)
+
+        collection = mocked_client['arbitrage']['trade_records']
+        collection.update_one.assert_called_once()
+        _, kwargs = collection.update_one.call_args
+        sent = collection.update_one.call_args[0]
+        sent_filter, sent_update = sent[0], sent[1]
+        assert sent_filter == {'trade_id': 'trade_xyz'}
+        legs = sent_update['$set']['legs']['SHORT_LEG']
+        assert legs['fee'] == '0.00057500'
+        assert legs['entry_price'] == '523.17'
+        # Non-decimal values pass through unchanged
+        assert sent_update['$set']['status'] == 'open'
+
+    def test_nested_decimal_in_long_leg_converted(self, mocker):
+        ops, mocked_client = self._make_ops(mocker)
+        update_data = {
+            'legs': {
+                'LONG_LEG': {
+                    'inst_code': 'ZEC-USDT_BN.SPOT',
+                    'position_size': Decimal('0.57500000'),
+                },
+            },
+        }
+        ops.update_trade_record('perp_sell_xxx', update_data)
+        sent_update = mocked_client['arbitrage']['trade_records'].update_one.call_args[0][1]
+        assert sent_update['$set']['legs']['LONG_LEG']['position_size'] == '0.57500000'


### PR DESCRIPTION
## Summary

排查 ZECUSDT 孤儿仓位时发现的两个独立问题。

### 1. `update_trade_record` 不处理 Decimal（CRITICAL）

\`mongodb_operations.update_trade_record\` 直接把 dict 透传给 pymongo：
- pymongo BSON encoder **不支持原生 \`Decimal\`**（只支持 \`Decimal128\`）
- \`insert_data\` 已经通过 \`get_correct_dict\` 把 Decimal 转 str，但 \`update_trade_record\` 没有
- 后果：trade record 首次 insert 成功后，**后续 update 全部抛 \`cannot encode object: Decimal('0.57500000')\` 静默失败**，记录永远停在初次写入的状态

线上证据（2026-05-18 cross_exchange_arbitrage_monitor 日志）：
\`\`\`
[monitor_trading_record.py:825] 10:52:24,023  INFO: Inserted trade record to MongoDB: perp_sell_1779101538645_c3806c2c
[monitor_trading_record.py:827] 10:52:27,552  WARNING: Failed to persist trade record for perp_sell_1779101538645_c3806c2c: cannot encode object: Decimal('0.57500000'), of type: <class 'decimal.Decimal'>
[monitor_trading_record.py:827] 10:52:30,260  WARNING: Failed to persist trade record for perp_sell_1779101538645_c3806c2c: cannot encode object: Decimal('0.57500000'), of type: <class 'decimal.Decimal'>
\`\`\`

修复：与 insert 对称，调用 \`get_correct_dict\` 转换。

### 2. \`binance_ws._on_message\` perp 事件加 DEBUG 日志

排查孤儿时发现 BN perp WS 没有 per-event 日志，无法判断 \`ORDER_TRADE_UPDATE\` 是真没到、被过滤、还是被吞。

加一行 DEBUG（默认关闭，需要开关 \`LOG_LEVEL=DEBUG\` 才输出）：
\`\`\`
perp ORDER_TRADE_UPDATE: symbol=ZECUSDT clientOrderId=perp_sell_xxx status=FILLED side=SELL
\`\`\`

仅 DEBUG 级，info 行为不变，运行时开销可忽略。

## Test plan

- [x] \`tests/test_mongodb_operations.py\` 5/5 通过（含 2 个新增 Decimal 用例）
- [x] 全量 pytest 115 passed（main 上 113），唯一失败 \`test_arbitrage_data_types\` 在 main 上同样失败，与本 PR 无关
- [ ] 合并后下游 cross_exchange_arbitrage 重建相关镜像（\`--no-cache\` 因为是 git+@main 依赖）

## 后续

下游 cross_exchange_arbitrage 还有两个待修：
- \`sl/liq_hedge\` 类订单不走 \`_store_order_link\` 导致 spot trade 走 fallback
- perp order 占位-vs-WS 超时报警

🤖 Generated with [Claude Code](https://claude.com/claude-code)