### PR TITLE
fix(redis_operations): logger.exception → logger.debug(exc_info=True) + 英文 docstring

### DIFF
--- a/pytradekit/utils/redis_operations.py
+++ b/pytradekit/utils/redis_operations.py
@@ -337,7 +337,7 @@ class RedisOperations:
             with lock:
                 value = self.client.get(key)
         except Exception as e:
-            self.logger.exception(f"Failed to get target premium for {order_id}: {e}")
+            self.logger.debug(f"Failed to get target premium for {order_id}: {e}", exc_info=True)
             raise DependencyException(f"Failed to get target premium for {order_id}") from e
 
         if value is None:
@@ -345,7 +345,7 @@ class RedisOperations:
         try:
             return Decimal(value)
         except InvalidOperation as e:
-            self.logger.exception(f"Invalid premium value for {order_id}: {value!r}")
+            self.logger.debug(f"Invalid premium value for {order_id}: {value!r}", exc_info=True)
             raise DataTypeException(f"Invalid premium value for {order_id}: {value!r}") from e
 
     def ping(self):
@@ -353,7 +353,7 @@ class RedisOperations:
         try:
             self.client.ping()
         except Exception as e:
-            self.logger.exception(f"Redis ping failed: {e}")
+            self.logger.debug(f"Redis ping failed: {e}", exc_info=True)
             raise DependencyException("Redis ping failed") from e
 
     def create_pubsub(self):
@@ -361,7 +361,7 @@ class RedisOperations:
         try:
             return self.client.pubsub()
         except Exception as e:
-            self.logger.exception(f"Failed to create pubsub: {e}")
+            self.logger.debug(f"Failed to create pubsub: {e}", exc_info=True)
             raise DependencyException("Failed to create pubsub") from e
 
     def close(self):
@@ -369,5 +369,5 @@ class RedisOperations:
         try:
             self.client.close()
         except Exception as e:
-            self.logger.exception(f"Failed to close Redis connection: {e}")
+            self.logger.debug(f"Failed to close Redis connection: {e}", exc_info=True)
             raise DependencyException("Failed to close Redis connection") from e

--- a/tests/test_redis_operations.py
+++ b/tests/test_redis_operations.py
@@ -18,7 +18,11 @@ def redis_ops(mocker):
 
 @dataclass
 class FailureSpec:
-    """绑定一次失败注入所需的客户端属性、待测操作与调用参数。"""
+    """Spec for injecting a single client-level failure into an ops method.
+
+    Bundles the client attribute to fail (e.g. "ping"), the ops method to call
+    (e.g. "ping"), and the positional args to pass.
+    """
     client_attr: str
     op_name: str
     op_args: Tuple = field(default_factory=tuple)
@@ -28,7 +32,8 @@ def assert_wraps_as_dependency_exception(redis_ops, spec: FailureSpec):
     """Assert ops.<op_name>(*op_args) wraps a client error as DependencyException.
 
     Covers all three failure behaviors in one call:
-    raises DependencyException, chains __cause__, calls logger.exception once.
+    raises DependencyException, chains __cause__, logs once at debug level
+    with exc_info=True (CLAUDE.md restricts logging to debug/info only).
     """
     ops, client, logger = redis_ops
     original = Exception("boom")
@@ -36,7 +41,10 @@ def assert_wraps_as_dependency_exception(redis_ops, spec: FailureSpec):
     with pytest.raises(DependencyException) as exc_info:
         getattr(ops, spec.op_name)(*spec.op_args)
     assert exc_info.value.__cause__ is original
-    logger.exception.assert_called_once()
+    logger.debug.assert_called_once()
+    # exc_info=True so the traceback still lands in logs even though level is debug
+    _, kwargs = logger.debug.call_args
+    assert kwargs.get('exc_info') is True
 
 
 class TestPing:


### PR DESCRIPTION
## Summary

昨日 code review 在 \`tests/test_redis_operations.py\` 指出两处违规：

### 1. \`tests/test_redis_operations.py:21\` 中文 docstring

\`FailureSpec\` 的 \`"""绑定一次失败注入..."""\` 违反 CLAUDE.md「代码和注释使用英文」规范。改为英文 docstring。

### 2. \`tests/test_redis_operations.py:39\` 隐含生产代码用 logger.exception

\`logger.exception.assert_called_once()\` 反映 \`redis_operations.py\` 用了 \`logger.exception(...)\`，违反 CLAUDE.md「日志仅用 debug 和 info」规范。

修复测试覆盖的 4 个生产函数（含 \`get_target_premium\` 2 处 exception）：

| 函数 | 改动 |
|------|------|
| \`ping\` | \`logger.exception\` → \`logger.debug(..., exc_info=True)\` |
| \`create_pubsub\` | 同上 |
| \`close\` | 同上 |
| \`get_target_premium\` | 2 处 exception → debug |

\`exc_info=True\` 保留 traceback 进日志，仅降级为 debug 级别（默认不输出，不触发 Slack/Lark）。

测试断言同步改：\`logger.exception.assert_called_once()\` → \`logger.debug.assert_called_once()\`，并新增 \`exc_info=True\` 参数验证。

## 范围说明

\`logger.exception/error/warning\` 在 pytradekit 全局共 75 处，本 PR **只动 CR 直接点名的 4 个函数**：

| 文件 | 总数 |
|------|------|
| redis_operations.py | 33（本 PR 改 4） |
| binance_ws.py | 10 |
| binance_restful.py | 6 |
| slack_app/chat_app.py | 5 |
| 其它 ws/restful | 16 |
| **合计** | **75** |

剩余 71 处规模较大，单独 PR 系统性清理。

## Test plan

- [x] \`tests/test_redis_operations.py\` 11/11 通过（docker python:3.11）
- [x] 全量 pytest 115 passed（含 1 个 pre-existing failure 与本 PR 无关）
- [ ] 合并并下游 \`--no-cache\` 重建后，redis 失败场景仍能正确抛 DependencyException，traceback 进 debug 日志

🤖 Generated with [Claude Code](https://claude.com/claude-code)