### PR TITLE
fix(okex_restful): get_perp_position 使用 'SWAP' 字面值

### DIFF
--- a/pytradekit/restful/okex_restful.py
+++ b/pytradekit/restful/okex_restful.py
@@ -65,7 +65,8 @@ class OkexClient:
             return e
 
     def get_perp_position(self, symbol):
-        params = {'instType': InstCodeType.SWAP.name, 'instId': symbol + "-" + InstCodeType.SWAP.name}
+        # OKX API protocol uses 'SWAP' as instType for perpetual contracts — keep literal.
+        params = {'instType': 'SWAP', 'instId': symbol + "-SWAP"}
         url = OkexAuxiliary.url_perp_position.value
         datas = self._send_request(url, method=HttpMmthod.GET.name, params=params)
         return datas


### PR DESCRIPTION
## Summary

- `InstCodeType` 枚举只有 `SPOT/PERP/FUTU`，**没有 SWAP**。`okex_restful.py:68` 原代码 `InstCodeType.SWAP.name` 运行时会 `AttributeError`。
- OKX API 协议中 `instType=SWAP` 是表示永续合约的外部协议值，与项目内部的 `PERP` 命名是两个概念。
- 改为字面量 `'SWAP'`，加注释说明这是 OKX 外部 API 协议值。

## Test plan
- [ ] 后续运行 OKX `get_perp_position` 调用不再 `AttributeError`
- [ ] 不影响 SPOT 路径

🤖 Generated with [Claude Code](https://claude.com/claude-code)