### PR TITLE
test(mongodb_operations): 测试隔离 + InstCode 类型使用 (code review)

### DIFF
--- a/tests/test_mongodb_operations.py
+++ b/tests/test_mongodb_operations.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 
+from pytradekit.utils.custom_types import InstCode
 from pytradekit.utils.mongodb_operations import MongodbOperations
 
 
@@ -32,6 +33,12 @@ def test_close(mocker):
 
 
 def test_check_connection(mocker):
+    # 重置 singleton 状态，使 mocker.patch 的 MongoClient 一定被注入
+    # （如果 _client 已被前序测试初始化过，__init__ 会跳过 _create_client，
+    # mocked_mongo_client 永远不会成为 self.client，断言会因执行顺序失败）
+    MongodbOperations._client = None
+    MongodbOperations._indexes_ensured = False
+
     # 创建MongoClient的模拟实例
     mocked_mongo_client = mocker.Mock()
     # 创建admin属性的模拟对象
@@ -43,6 +50,8 @@ def test_check_connection(mocker):
 
     # 使用patch替换MongoClient，使其返回模拟的MongoClient实例
     mocker.patch('pytradekit.utils.mongodb_operations.MongoClient', return_value=mocked_mongo_client)
+    # _ensure_indexes 在 __init__ 中会被调用，mock 掉避免访问 mock client 的索引方法链
+    mocker.patch.object(MongodbOperations, '_ensure_indexes')
 
     mongodb_operations_instance = MongodbOperations(MONGODB_URL)
     # 调用待测试的方法
@@ -91,10 +100,13 @@ class TestUpdateTradeRecordStripsDecimal:
 
     def test_nested_decimal_in_long_leg_converted(self, mocker):
         ops, mocked_client = self._make_ops(mocker)
+        # inst_code 通过 InstCode 类构造而非裸字符串，遵守 CLAUDE.md
+        # 「交易对标识必须使用 InstCode 类和转换方法」，同时验证字符串格式
+        # 可被 InstCode.from_string 解析。
         update_data = {
             'legs': {
                 'LONG_LEG': {
-                    'inst_code': 'ZEC-USDT_BN.SPOT',
+                    'inst_code': str(InstCode.from_string('ZEC-USDT_BN.SPOT')),
                     'position_size': Decimal('0.57500000'),
                 },
             },


### PR DESCRIPTION
## Summary

针对昨天 code review 三个发现的处置：

| 发现 | 决策 | 说明 |
|---|---|---|
| F1: `test_check_connection` 未重置 singleton | ✅ apply | 测试顺序不固定时 `mocker.patch` 的 `MongoClient` 永远不会被注入 |
| F2: `spy.assert_called_once_with(MONGODB_URL)` 含 `self` | ⏭️ **skip** | 审查者前提不成立——`_create_client` 是 `@staticmethod`（[mongodb_operations.py:164](https://github.com/halfshade-labs/pytradekit/blob/main/pytradekit/utils/mongodb_operations.py#L164)），spy 不会带 self |
| F3: `inst_code: 'ZEC-USDT_BN.SPOT'` 裸字符串 | ✅ apply | 用 `str(InstCode.from_string(...))` 包一层，增加格式验证 |

## F1 详情

`test_close` 在第一行就重置了 `_client` / `_indexes_ensured`，但 `test_check_connection` 没有。pytest 测试顺序不固定：

- 若 `test_check_connection` 先跑 → singleton 还是 None，`__init__` 走 `_create_client` 分支，`mocker.patch` 的 `MongoClient` 成功注入，测试通过
- 若有其他测试先于它跑并初始化了 singleton → `__init__` 的 `if _client is None` 分支跳过，`mocker.patch` 完全没生效，`self.client` 还是上一个测试的 mock —— `mocked_admin.command.assert_called_once_with('ping')` 这个断言可能因 mock 错位而失败

修复：在第 35 行前补 `_client = None` / `_indexes_ensured = False`，与 `test_close` 一致。同时补 `mocker.patch.object(MongodbOperations, '_ensure_indexes')` 防止 mock client 在 `__init__` 调用索引创建链时报错。

## F2 为何 skip

`_create_client` 已经是 `@staticmethod`：
```python
@staticmethod
def _create_client(mongodb_url):
    ...
```
当 `mocker.spy(MongodbOperations, '_create_client')` 包装后，再通过 `self._create_client(url)` 调用，staticmethod descriptor 会去掉 self。所以 `spy.call_args == call('mongodb://...')`，原 `spy.assert_called_once_with(MONGODB_URL)` 正确。

如果审查者基于「实例方法」假设，那是误判文件状态。

## F3 详情

虽然测试只是落库字符串、未做 split/replace 操作（CLAUDE.md 原文禁止的是「拼接/split/replace」），但用 `InstCode` 包一层有两个收益：
1. 把字符串格式正确性变成测试时即时验证（写错的字符串过不去）
2. 下次重构 InstCode 字符串格式时测试会自动失败

## Test plan

```
sudo docker run --rm -v $(pwd):/app -w /app python:3.11 bash -c   "pip install -r requirements.txt -q && pip install pytest-mock -q &&    python -m pytest tests/test_mongodb_operations.py -v"
```
→ 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)