### PR TITLE
fix(binance_restful): 同步 session 加 Retry+timeout，修复 RemoteDisconnected 风暴

### DIFF
--- a/pytradekit/restful/binance_restful.py
+++ b/pytradekit/restful/binance_restful.py
@@ -4,6 +4,8 @@ import time
 
 import httpx
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 import base64
 
 from cryptography.hazmat.primitives import serialization
@@ -19,6 +21,11 @@ RECVWINDOW = 6000
 RETRY_TIMES = 10
 RETRY_INTERVAL = 5
 
+# 同步 HTTP 重试配置：BN 服务端会主动关闭 idle ≥ 60s 的 keep-alive 连接，
+# 长生命周期复用 session 时下次请求会拿到死 socket 触发 RemoteDisconnected。
+# 仅对 GET 自动重试，避免 POST/DELETE（下单/撤单）被重复执行。
+SYNC_HTTP_TIMEOUT = (5, 30)  # (connect, read)
+
 
 class BinanceClient:
     def __init__(self, logger, key=None, secret=None, passphrase=None, account_id=None, is_perp=False, is_alpha=False):
@@ -28,6 +35,16 @@ class BinanceClient:
         self.passphrase = passphrase
         self.account_id = account_id
         self.session = requests.session()
+        retry = Retry(
+            total=3, connect=3, read=3,
+            backoff_factor=0.3,
+            status_forcelist=[502, 503, 504],
+            allowed_methods=frozenset(['GET']),
+            raise_on_status=False,
+        )
+        adapter = HTTPAdapter(max_retries=retry, pool_connections=10, pool_maxsize=20)
+        self.session.mount('https://', adapter)
+        self.session.mount('http://', adapter)
         self.logger = logger
         if is_perp:
             self._url = BinanceAuxiliary.perp_url.value
@@ -59,11 +76,11 @@ class BinanceClient:
                 headers["X-MBX-APIKEY"] = self.api_key
 
             if method == "GET":
-                resp = self.session.get(url, headers=headers, params=params)
+                resp = self.session.get(url, headers=headers, params=params, timeout=SYNC_HTTP_TIMEOUT)
             elif method == "POST":
-                resp = self.session.post(url, headers=headers, data=params)
+                resp = self.session.post(url, headers=headers, data=params, timeout=SYNC_HTTP_TIMEOUT)
             elif method == "DELETE":
-                resp = self.session.delete(url, headers=headers, data=params)
+                resp = self.session.delete(url, headers=headers, data=params, timeout=SYNC_HTTP_TIMEOUT)
             else:
                 raise ExchangeException(f"Unsupported HTTP method: {method}")
 


### PR DESCRIPTION
## 背景

CEA `monitor_trading_record` 服务长生命周期复用 `BinanceClient.session`（`is_perp=True`），同时被 `ShortLegBackfiller`、`CloseLegBackfiller`、`BinancePerpPositionRiskFetcher`、`BinanceFundingRate`、`BinanceFundingFeeIncome` 共享。

2026-06-02 全天观测到 **174 次 \`exchange connect error\`** WARNING，分布全天每小时 ~10 次，根因：

\`\`\`
('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
\`\`\`

## 根因

1. \`BinanceClient.__init__\` 创建 \`requests.session()\`，全进程共享 urllib3 connection pool
2. BN 服务端会主动关闭 idle ≥ 60–90s 的 HTTP/1.1 keep-alive 连接
3. 下次请求时 urllib3 从 pool 拿出**已被对端关闭的 socket**，read 时遇 EOF → \`RemoteDisconnected\`
4. 同步 \`request()\` **无 retry、无 timeout、无 ConnectionError 捕获**，直接抛 \`ExchangeException\`
5. 调用方（如 backfill）只能 log warning 跳过；下个轮询周期大概率又拿到死连接

对比 \`async_request()\` 已有 \`@async_retry_decorator\` + httpx \`timeout=5\`，同步路径是裸奔短板。

## 修复

\`BinanceClient.__init__\` 给 session 挂 \`HTTPAdapter + urllib3.Retry\`：

\`\`\`python
retry = Retry(
    total=3, connect=3, read=3,
    backoff_factor=0.3,              # 0.3, 0.6, 1.2s 指数退避
    status_forcelist=[502, 503, 504],
    allowed_methods=frozenset(['GET']),  # 仅 GET 重试
    raise_on_status=False,
)
\`\`\`

并在 \`session.get/post/delete\` 上加 \`timeout=(5, 30)\`（connect 5s / read 30s），避免裸奔无限等待。

## 安全性

- ✅ \`allowed_methods=['GET']\` 严格限制重试方法：**POST/DELETE 永不自动重试**，杜绝下单 / 撤单被重复执行的风险
- ✅ \`raise_on_status=False\` 保持现有 HTTP 错误处理逻辑不变（4xx 仍由调用方处理）
- ✅ \`pool_maxsize=20\` 适度连接复用，不引入额外负担
- ✅ \`urllib3 2.7.0\` (生产环境实测版本) 支持 \`allowed_methods\` API（2.x 后官方推荐）

## Impact Check

- 交易执行：⚠ 下单/撤单走 POST/DELETE，**不会被自动重试**（已显式排除）
- 风控：无影响（无逻辑变更）
- 行情/历史拉取（GET）：✅ 死连接自动重连，告警风暴消除
- 数据一致性：无影响（GET 幂等）

## Test plan
- [ ] 重建 CEA monitor 镜像（\`--no-cache\` 拉取 pytradekit\@main 新 commit）+ 重启
- [ ] 24h 观察 \`monitor_trading_record.log\` 中 \`exchange connect error\` 计数应降至个位
- [ ] 验证下单链路（OKX/BN 现货 SELL）未受影响，无重复成交

🤖 Generated with [Claude Code](https://claude.com/claude-code)