### PR TITLE
fix(okex_restful): session 复用 + raise 异常 + Decimal 手续费

### DIFF
--- a/pytradekit/restful/okex_restful.py
+++ b/pytradekit/restful/okex_restful.py
@@ -57,11 +57,13 @@ class OkexClient:
             elif method == HttpMmthod.POST.name:
                 resp = self.session.post(url, json=params, headers=headers)
             else:
-                return f'method {method} not support'
+                raise ExchangeException(f'method {method} not support')
             if resp.status_code != 200:
-                return f'http err:{resp.status_code} result:{resp.content}'
+                raise ExchangeException(f'http err:{resp.status_code} result:{resp.content}')
             result = resp.json()
             return result
+        except ExchangeException:
+            raise
         except Exception as e:
             raise ExchangeException(str(e))
 

--- a/pytradekit/restful/okex_restful.py
+++ b/pytradekit/restful/okex_restful.py
@@ -8,6 +8,7 @@ import requests
 from pytradekit.utils.time_handler import get_ok_timestamp
 from pytradekit.utils.dynamic_types import HttpMmthod, OkexAuxiliary, InstCodeType
 from pytradekit.utils.static_types import FeeStructureKey
+from pytradekit.utils.exceptions import ExchangeException
 
 
 class OkexClient:
@@ -52,9 +53,9 @@ class OkexClient:
             if method == HttpMmthod.GET.name:
                 if params:
                     url = f'{url}?{urlencode(params)}'
-                resp = requests.get(url, headers=headers)
+                resp = self.session.get(url, headers=headers)
             elif method == HttpMmthod.POST.name:
-                resp = requests.post(url, json=params, headers=headers)
+                resp = self.session.post(url, json=params, headers=headers)
             else:
                 return f'method {method} not support'
             if resp.status_code != 200:
@@ -62,7 +63,7 @@ class OkexClient:
             result = resp.json()
             return result
         except Exception as e:
-            return e
+            raise ExchangeException(str(e))
 
     def get_perp_position(self, symbol):
         # OKX API protocol uses 'SWAP' as instType for perpetual contracts — keep literal.
@@ -77,13 +78,13 @@ class OkexClient:
         datas = self._send_request(url, method=HttpMmthod.GET.name, params=params)
         return datas
 
-    def get_ticker_24hr(self, inst_type='SPOT'):
+    def get_ticker_24hr(self, inst_type=InstCodeType.SPOT.name):
         params = {'instType': inst_type}
         url = OkexAuxiliary.url_ticker.value
         datas = self._send_request(url, method=HttpMmthod.GET.name, params=params, use_sign=False)
         return datas
 
-    def get_exchange_information(self, inst_type='SPOT'):
+    def get_exchange_information(self, inst_type=InstCodeType.SPOT.name):
         params = {'instType': inst_type}
         url = OkexAuxiliary.url_exchange.value
         datas = self._send_request(url, method=HttpMmthod.GET.name, params=params, use_sign=False)
@@ -153,7 +154,7 @@ class OkexClient:
         datas = self._send_request(url, method=HttpMmthod.GET.name, params=params, use_sign=True)
         return datas
 
-    def get_commission_rate(self, inst_type='SPOT', inst_id=None):
+    def get_commission_rate(self, inst_type=InstCodeType.SPOT.name, inst_id=None):
         """
         Get commission rate for an instrument.
         
@@ -174,19 +175,21 @@ class OkexClient:
             if result and isinstance(result, dict):
                 if result.get('code') == '0' and 'data' in result:
                     data_list = result['data']
+                    fee_data = None
                     if isinstance(data_list, list) and len(data_list) > 0:
                         fee_data = data_list[0]
-                        maker_rate = float(fee_data.get('maker', 0))
-                        taker_rate = float(fee_data.get('taker', 0))
-                        return {FeeStructureKey.maker.name: maker_rate, FeeStructureKey.taker.name: taker_rate}
                     elif isinstance(data_list, dict):
-                        maker_rate = float(data_list.get('maker', 0))
-                        taker_rate = float(data_list.get('taker', 0))
-                        return {FeeStructureKey.maker.name: maker_rate, FeeStructureKey.taker.name: taker_rate}
+                        fee_data = data_list
+                    if fee_data is not None:
+                        return {
+                            FeeStructureKey.maker.name: Decimal(str(fee_data.get('maker', 0))),
+                            FeeStructureKey.taker.name: Decimal(str(fee_data.get('taker', 0))),
+                        }
             return None
         except Exception as e:
             if self.logger:
-                self.logger.info(f"Failed to get commission rate from OKX for {inst_type}/{inst_id}: {e}")
+                # 静默降级路径，避免 info 触发 Slack/Lark 通知；上层调用方会拿到 None 自行处理。
+                self.logger.debug(f"Failed to get commission rate from OKX for {inst_type}/{inst_id}: {e}")
             return None
 
     def place_spot_market_order(self, inst_id, side, size, client_order_id=None):


### PR DESCRIPTION
## Summary
针对 code review 反馈的 okex_restful.py 整改。

- **Session 复用**：`requests.get/post` → `self.session.get/post`，启用 `__init__` 中创建的连接池
- **异常传播**：`return e`（静默失败，调用方无法区分） → `raise ExchangeException(str(e))`
- **枚举引用**：3 处 `inst_type='SPOT'` 默认值改为 `InstCodeType.SPOT.name`
- **Decimal**：`get_commission_rate` 手续费率 `float` → `Decimal(str(...))`
- **DRY**：list / dict 两个返回分支统一逻辑
- **日志**：降级路径 `info` → `debug`，避免触发 Slack/Lark

## ⚠ 行为变更（破坏性）

- `_send_request` 现在会抛 `ExchangeException` 而不是返回异常对象。调用方原本依赖 "返回值是 dict 就是成功" 的隐式假设需复查。本次主要影响 OkexClient 的所有 caller（liquidity_monitor / liquidity_provider / CEA 中所有用到 OkexClient 的路径）。
- `get_commission_rate` 返回值的 `maker/taker` 从 `float` 改为 `Decimal`，调用方做算术运算时若混入 `float` 需注意类型一致。

## Test plan
- [ ] CI 通过
- [ ] 合并后观察 OKX 相关 cron 是否有未预期的 ExchangeException 上抛
- [ ] 验证 commission rate 下游使用方对 Decimal 类型兼容

🤖 Generated with [Claude Code](https://claude.com/claude-code)