### PR TITLE
feat(dynamic_types): 补 StrategyId.PERP 与 BybitSwapRestful 三个枚举值

### DIFF
--- a/pytradekit/utils/dynamic_types.py
+++ b/pytradekit/utils/dynamic_types.py
@@ -34,6 +34,7 @@ class StrategyId:
     VENDOR = 'vendor'
     TRONMM = 'tronmm'
     GRID = 'GRID'
+    PERP = 'perp'
 
 
 class InstCodeType(Enum):
@@ -1319,6 +1320,9 @@ class BybitSwapRestful(Enum):
     cumRealisedPnl = auto()
     currency = auto()
     borrowCost = auto()
+    interest = auto()
+    tradeId = auto()
+    transactionId = auto()
 
 
 class GateSwapRestful(Enum):


### PR DESCRIPTION
## Summary
- 新增 `StrategyId.PERP = 'perp'`，作为永续合约场景下的 portfolio/strategy 标识枚举，替代业务项目里散落的裸字符串 `'swap'` / `'perp'`
- `BybitSwapRestful` 枚举新增 `interest` / `tradeId` / `transactionId` 三个字段，供 liquidity_monitor Bybit perp_income fetcher 引用 API 字段名，消除 literal

## 背景
liquidity_monitor 的 `fetch_restful_bit_perp_position.py` code review 反馈：
- `strategy_id = 'swap'` / `portfolio_id = 'swap'` 既命名错（永续应为 perp 不是 swap），又用裸字符串
- `income_type = BybitSwapRestful.cross.name`（语义错，应为 interest）
- `trade_id=0, tran_id=0` 硬编码丢字段

下游 PR（liquidity_monitor）依赖本 PR merge 后才能 import 这几个枚举。

## Test plan
- [ ] CI 通过
- [ ] 确认无下游引用旧的 'swap' literal 失配