### PR TITLE
chore(PremiumStatus): rename close → closed

### DIFF
--- a/pytradekit/utils/dynamic_types.py
+++ b/pytradekit/utils/dynamic_types.py
@@ -1397,5 +1397,5 @@ class TradingProposalType(Enum):
 class PremiumStatus(Enum):
     open = auto()
     open_pending = auto()
-    close = auto()
+    closed = auto()
     close_pending = auto()


### PR DESCRIPTION
## Summary
- `PremiumStatus.close` 重命名为 `PremiumStatus.closed`
- 原命名让人误以为是"关仓中"中间态（与 `close_pending` 同级），实际是关仓完成终态；改名后与 `open` 形成清晰的开/关对偶

## 背景
BILLUSDT 对冲对账时误判：mongo 看到 status='close' + long_close_price=null 的记录，凭直觉以为 close_executor 卡在 spot 端没平。实际：
- `close` 在新代码里就是终态
- 老数据里有 5 条 status='closed' 是手动 reconcile 时写的，9 条 status='close' 是新代码写的——同一含义、两个值
- HTX 的 long_close_price=null 是 backfill_close_leg 显式 skip 了 HTX REST 查询（cosmetic，不影响 status）

## 下游迁移
本 PR 只动 pytradekit 枚举值，下游 CEA 在 [cross_exchange_arbitrage 跟进 PR](TBD) 同步：
- 代码：3 处 `PremiumStatus.close.name` → `PremiumStatus.closed.name`（backfill_close_leg.py, monitor_trading_record.py × 2）
- 数据：mongo `trade_records` 9 条 status='close' → 'closed' 一次性迁移脚本

其他两个业务 repo（liquidity_provider / liquidity_monitor）经 grep 确认无 `PremiumStatus.close` 引用。

## 部署顺序
1. merge 本 PR
2. merge CEA 跟进 PR
3. 跑 mongo migration 脚本
4. 重建 CEA 镜像 `docker compose build --no-cache`（拉新 pytradekit）

## Test plan
- [x] grep 全 4 个 repo 确认无遗漏引用
- [ ] CI 通过