### PR TITLE
fix(time_handler): TimeConvert 加 DAY_TO_MS 别名

### DIFF
--- a/pytradekit/utils/time_handler.py
+++ b/pytradekit/utils/time_handler.py
@@ -50,7 +50,8 @@ class TimeConvert:
     HOUR_TO_MS = 60 * 60 * 1000
     HOUR_TO_S = 60 * 60
     DAY_TO_S = 60 * 60 * 24
-    DAT_TO_MS = 60 * 60 * 24 * 1000
+    DAY_TO_MS = 60 * 60 * 24 * 1000
+    DAT_TO_MS = DAY_TO_MS  # backward-compat alias for legacy typo
 
 
 class CronKey(Enum):


### PR DESCRIPTION
## Summary
- 给 `TimeConvert` 加 `DAY_TO_MS = 60 * 60 * 24 * 1000` 作为正名
- `DAT_TO_MS` 保留为向后兼容别名（`= DAY_TO_MS`），现有调用方（`bitget_restful` 等）无需改动
- 配合 halfshade-labs/liquidity_monitor#59 使用 `DAY_TO_MS`，解决 auto-review issue halfshade-labs/liquidity_monitor#52

## Test plan
- [ ] 确认 `from pytradekit.utils.time_handler import TimeConvert; TimeConvert.DAY_TO_MS == TimeConvert.DAT_TO_MS`
- [ ] grep 现有 `DAT_TO_MS` 调用方仍可用

🤖 Generated with [Claude Code](https://claude.com/claude-code)