### PR TITLE
fix(binance): -1013 按 filter 子类区分 LOT_SIZE 与 MIN_NOTIONAL (#68)

### DIFF
--- a/pytradekit/restful/binance_restful.py
+++ b/pytradekit/restful/binance_restful.py
@@ -13,7 +13,7 @@ from nacl.signing import SigningKey
 
 from pytradekit.utils import time_handler
 from pytradekit.utils.dynamic_types import HttpMmthod, RestfulRequestsAttribute, BinanceAuxiliary, BinanceRestful, InstCodeType
-from pytradekit.utils.exceptions import ExchangeException, MinNotionalException, InsufficientBalanceException
+from pytradekit.utils.exceptions import ExchangeException, MinNotionalException, LotSizeException, InsufficientBalanceException
 from pytradekit.utils.tools import async_retry_decorator
 from pytradekit.utils.static_types import FeeStructureKey
 
@@ -133,7 +133,20 @@ class BinanceClient:
             result = resp.json()
             if 'code' in result:
                 if result['code'] == -1013:
-                    return None, MinNotionalException.__name__
+                    # BN -1013 is a generic "Filter failure" covering several sub-types
+                    # (LOT_SIZE / MIN_NOTIONAL / PRICE_FILTER / ...); the specific one
+                    # is in `msg`. Blindly mapping all to MinNotionalException misled
+                    # callers (e.g. LOT_SIZE step misalignment retried as min-notional).
+                    msg = result.get('msg') or ''
+                    upper = msg.upper()
+                    if 'NOTIONAL' in upper:
+                        return None, MinNotionalException.__name__
+                    if 'LOT_SIZE' in upper:
+                        return None, LotSizeException.__name__
+                    # other -1013 filter failures: surface the raw msg instead of
+                    # mislabeling, so the actual filter is visible to the caller.
+                    self.logger.debug(f'BN -1013 filter failure (unclassified): {msg}')
+                    return None, f'BN -1013 filter failure: {msg}' if msg else 'BN -1013 filter failure'
                 if result['code'] == -2010:
                     return None, InsufficientBalanceException.__name__
             if resp.status_code != 200:

--- a/pytradekit/utils/exceptions.py
+++ b/pytradekit/utils/exceptions.py
@@ -47,6 +47,12 @@ class MinNotionalException(JwjException):
         self.note = note
 
 
+class LotSizeException(JwjException):
+    def __init__(self, note=None):
+        super().__init__('order quantity not aligned to lot size step')
+        self.note = note
+
+
 class PlaceOrderException(JwjException):
     def __init__(self, note=None):
         super().__init__('place order exception')

--- a/tests/test_binance_restful.py
+++ b/tests/test_binance_restful.py
@@ -1,0 +1,73 @@
+import asyncio
+
+import pytest
+from unittest.mock import Mock, AsyncMock
+
+from pytradekit.restful.binance_restful import BinanceClient
+from pytradekit.utils.exceptions import MinNotionalException, LotSizeException
+
+
+class FakeResp:
+    """Minimal stand-in for an httpx Response used by async_request."""
+
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.content = b""
+        self.headers = {}
+
+    def json(self):
+        return self._payload
+
+
+def _make_client():
+    # Bypass __init__: it decrypts an Ed25519 PEM key, which is irrelevant here.
+    # async_request only needs self.logger and self.api_key.
+    client = BinanceClient.__new__(BinanceClient)
+    client.logger = Mock()
+    client.api_key = "test-api-key"
+    return client
+
+
+def _run_request(client):
+    # http_client truthy -> async_request uses self.requests_result (mocked), no real network.
+    return asyncio.new_event_loop().run_until_complete(
+        client.async_request("POST", "http://example/order", http_client=object())
+    )
+
+
+@pytest.mark.parametrize(
+    "msg,expected",
+    [
+        ("Filter failure: MIN_NOTIONAL", MinNotionalException.__name__),
+        ("Filter failure: NOTIONAL", MinNotionalException.__name__),
+        ("Filter failure: LOT_SIZE", LotSizeException.__name__),
+        ("Filter failure: MARKET_LOT_SIZE", LotSizeException.__name__),
+    ],
+)
+def test_bn_1013_classified_by_msg(msg, expected):
+    client = _make_client()
+    client.requests_result = AsyncMock(return_value=FakeResp({"code": -1013, "msg": msg}))
+    data, err = _run_request(client)
+    assert data is None
+    assert err == expected
+
+
+def test_bn_1013_other_filter_surfaces_raw_msg():
+    client = _make_client()
+    client.requests_result = AsyncMock(
+        return_value=FakeResp({"code": -1013, "msg": "Filter failure: PRICE_FILTER"})
+    )
+    data, err = _run_request(client)
+    assert data is None
+    assert "PRICE_FILTER" in err
+    assert err not in (MinNotionalException.__name__, LotSizeException.__name__)
+
+
+def test_bn_success_passthrough():
+    client = _make_client()
+    payload = {"orderId": 123, "status": "FILLED"}
+    client.requests_result = AsyncMock(return_value=FakeResp(payload))
+    data, err = _run_request(client)
+    assert err is None
+    assert data == payload

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -1,5 +1,5 @@
 import pytest
-from pytradekit.utils.exceptions import JwjException, NoDataException, ExchangeException, DataTypeException
+from pytradekit.utils.exceptions import JwjException, NoDataException, ExchangeException, DataTypeException, MinNotionalException, LotSizeException
 
 
 def test_jwj_exception():
@@ -27,3 +27,18 @@ def test_data_type_exception():
         raise DataTypeException(note="Expected int but got str")
     assert str(excinfo.value) == "data type is not as except"
     assert excinfo.value.note == "Expected int but got str"
+
+
+def test_min_notional_exception():
+    with pytest.raises(MinNotionalException) as excinfo:
+        raise MinNotionalException(note="qty too small")
+    assert str(excinfo.value) == "trade amount below minimum notional value"
+    assert excinfo.value.note == "qty too small"
+
+
+def test_lot_size_exception():
+    with pytest.raises(LotSizeException) as excinfo:
+        raise LotSizeException(note="qty not aligned to step")
+    assert str(excinfo.value) == "order quantity not aligned to lot size step"
+    assert excinfo.value.note == "qty not aligned to step"
+    assert isinstance(excinfo.value, JwjException)


### PR DESCRIPTION
Closes #68

## 问题
BN `code=-1013` 是通用 "Filter failure"，涵盖 `LOT_SIZE` / `MIN_NOTIONAL` / `PRICE_FILTER` 等多个子类，具体类型在响应的 `msg` 字段。`async_request` 原实现把**所有** -1013 一律映射为 `MinNotionalException`：

```python
if result['code'] == -1013:
    return None, MinNotionalException.__name__
```

后果：`LOT_SIZE`（下单量未按 stepSize 对齐）被误判为"最小名义额不足"。下游若按 MinNotional 处理（典型如放大下单量重试），对 LOT_SIZE 是**错误补救**——step 不对齐，加量也修不好，只会徒劳重试。

## 改动
- 新增 **`LotSizeException`**（`JwjException` 子类，与现有异常同构，`note` 透出细节）。
- `async_request` 对 -1013 按 `msg` 分类：
  - 含 `NOTIONAL` → `MinNotionalException`（覆盖 `MIN_NOTIONAL` / `NOTIONAL`，行为不变）
  - 含 `LOT_SIZE` → `LotSizeException`（覆盖 `LOT_SIZE` / `MARKET_LOT_SIZE`）
  - 其余 filter failure → 返回**原始 msg** 而非误标，并 `debug` 记录，便于排错
- 测试：`test_exception` 增补 MinNotional/LotSize 用例；新增 `test_binance_restful` 覆盖 -1013 四类分类 + 其他 filter 原样透出 + 成功透传（仓库无 pytest-asyncio，用 `run_until_complete`，避免 silent skip）。

## 测试
全套 **127 passed**（容器 `python:3.11`）。

## 下游影响
- **pytradekit 消费方**（CEA / liquidity_monitor）：均不按错误字符串做控制流分支，仅透传/记录，安全；分类更准后日志可读性提升。CEA 的 `order_executor` 已在下单前按 stepSize 预截断规避 -1013，本修复进一步覆盖 step 不可得时的兜底分类。
- **liquidity_provider**：依赖独立的 `jwjbasis` 包（非 pytradekit），其 `trading_func` retry 逻辑对**非 MinNotional 错误本就 `break`**。因此当 jwjbasis 同步该修复后，LP 对 LOT_SIZE 的"无限放大重试"会自动消除。本 PR 仅覆盖 pytradekit 侧；jwjbasis 侧需另行同步（其源码不在本次工作区）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)