### PR TITLE
fix(setup): install_requires 补齐 cryptography/pytz/httpx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,8 @@ setuptools.setup(
         "concurrent-log-handler",
         "pycryptodome",
         "PyNaCl",
+        "cryptography",
+        "pytz",
+        "httpx",
     ]
 )


### PR DESCRIPTION
## 问题
pytradekit 代码实际 `import cryptography`（2 处）、`pytz`、`httpx`，但这三个仅在 `requirements.txt` / `shared_requirements.txt`，**未进 `setup.py` 的 `install_requires`**。

下游仓库用 `pip install pytradekit @ git+https://github.com/halfshade-labs/pytradekit.git@main` 安装时，pip 只读 `install_requires`（不读 requirements.txt），于是拿不到这三个包，运行/测试时 `ModuleNotFoundError`。

liquidity_provider 接 CI 时即因 `No module named 'cryptography'` 无法收集测试。

## 改动
`install_requires` 补上 `cryptography` / `pytz` / `httpx`（均经 grep 确认是 pytradekit 实际 import 的运行时依赖）。

## 验证
干净 python:3.11 容器 `pip install .` 后 `import cryptography, pytz, httpx` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)