### PR TITLE
chore: 移除残留 ads 常量 DATETIME_FORMAT_ADS (closes #14)

### DIFF
--- a/pytradekit/utils/time_handler.py
+++ b/pytradekit/utils/time_handler.py
@@ -12,7 +12,6 @@ DATETIME_FORMAT_DAY = '%Y-%m-%d'
 DATETIME_FORMAT_DAY2 = '%Y-%m-%d 00:00:00'
 DATETIME_FORMAT_HOUR = '%Y-%m-%d %H:00:00'
 DATETIME_FORMAT_HMS = '%H-%M-%S'
-DATETIME_FORMAT_ADS = '%Y-%m-%dT%H:%M:%S'
 DATETIME_FORMAT_HB = '%Y-%m-%dT%H:%M:%S'
 DATETIME_FORMAT_OKEX = '%Y-%m-%d %H:%M:%S.%fZ'
 TIME_ZONE = pytz.timezone('UTC')


### PR DESCRIPTION
## 背景
ads 功能已废弃，`ads_operations` / `AdsApi` / `AdsAttribute` 等早已从 pytradekit 移除，liquidity_provider 也已完成 jwjbasis→pytradekit 迁移并去除 ads 依赖。

`DATETIME_FORMAT_ADS` 是最后一处 ads 残留：定义于 `time_handler.py`，但 pytradekit 与三个业务仓**均无任何引用**。删除以收尾 #14。

## 测试
本地 docker（python:3.11）：**127 passed**。

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)