### PR TITLE
feat(redis): 增加 arbitrage_threshold 全局阈值读写 (#79)

### DIFF
--- a/pytradekit/utils/dynamic_types.py
+++ b/pytradekit/utils/dynamic_types.py
@@ -1366,6 +1366,7 @@ class RedisFields(Enum):
     portfolios = auto()
     premium = auto()
     order_link = auto()
+    arbitrage_threshold = auto()
 
 
 class DuplicateFields(Enum):

--- a/pytradekit/utils/redis_operations.py
+++ b/pytradekit/utils/redis_operations.py
@@ -19,6 +19,8 @@ ORDER_TICKER_EXPIRE_TIME = TimeConvert.MIN_TO_S * 30
 ORDERS_EXPIRE_TIME = TimeConvert.MIN_TO_S * 60
 PREMIUM_EXPIRE_TIME = TimeConvert.MIN_TO_S * 60 * 24 * 30
 ORDER_LINK_EXPIRE_TIME = TimeConvert.DAY_TO_S
+# Daily threshold; TTL > 24h so a single missed analyzer run does not drop it
+ARBITRAGE_THRESHOLD_EXPIRE_TIME = TimeConvert.DAY_TO_S * 2
 TIMEOUT_SECOND = 5
 
 
@@ -347,6 +349,40 @@ class RedisOperations:
         except InvalidOperation as e:
             self.logger.debug(f"Invalid premium value for {order_id}: {value!r}", exc_info=True)
             raise DataTypeException(f"Invalid premium value for {order_id}: {value!r}") from e
+
+    def set_arbitrage_threshold(self, value):
+        """Store the global arbitrage premium threshold (single key, no identifier).
+
+        Written daily by the premium analyzer and read by realtime_compute_premium.
+        """
+        key = RedisFields.arbitrage_threshold.name
+        lock = self.get_lock_for_resource(key)
+        try:
+            with lock:
+                self.client.set(key, str(value))
+                self.client.expire(key, ARBITRAGE_THRESHOLD_EXPIRE_TIME)
+        except Exception as e:
+            self.logger.exception(f"Failed to set arbitrage threshold: {e}")
+            raise DependencyException("Failed to set arbitrage threshold") from e
+
+    def get_arbitrage_threshold(self):
+        """Return the global arbitrage premium threshold as Decimal, or None if unset."""
+        key = RedisFields.arbitrage_threshold.name
+        lock = self.get_lock_for_resource(key)
+        try:
+            with lock:
+                value = self.client.get(key)
+        except Exception as e:
+            self.logger.debug(f"Failed to get arbitrage threshold: {e}", exc_info=True)
+            raise DependencyException("Failed to get arbitrage threshold") from e
+
+        if value is None:
+            return None
+        try:
+            return Decimal(value)
+        except InvalidOperation as e:
+            self.logger.debug(f"Invalid arbitrage threshold value: {value!r}", exc_info=True)
+            raise DataTypeException(f"Invalid arbitrage threshold value: {value!r}") from e
 
     def ping(self):
         """Verify the Redis connection is alive. Raises DependencyException on failure."""

--- a/tests/test_redis_operations.py
+++ b/tests/test_redis_operations.py
@@ -104,3 +104,43 @@ class TestGetTargetPremium:
             redis_ops,
             FailureSpec(client_attr="get", op_name="get_target_premium", op_args=("perp_sell_x",)),
         )
+
+
+class TestArbitrageThreshold:
+    def test_set_writes_value_and_expiry(self, redis_ops):
+        ops, client, _ = redis_ops
+        ops.set_arbitrage_threshold(Decimal("0.0042"))
+        client.set.assert_called_once_with("arbitrage_threshold", "0.0042")
+        client.expire.assert_called_once()
+        assert client.expire.call_args[0][0] == "arbitrage_threshold"
+
+    def test_get_returns_decimal_from_str_value(self, redis_ops):
+        ops, client, _ = redis_ops
+        client.get.return_value = "0.0042"
+        assert ops.get_arbitrage_threshold() == Decimal("0.0042")
+        client.get.assert_called_once_with("arbitrage_threshold")
+
+    def test_get_returns_none_when_key_missing(self, redis_ops):
+        ops, client, _ = redis_ops
+        client.get.return_value = None
+        assert ops.get_arbitrage_threshold() is None
+
+    def test_get_invalid_decimal_string_raises_data_type_exception(self, redis_ops):
+        ops, client, _ = redis_ops
+        client.get.return_value = "not-a-number"
+        with pytest.raises(DataTypeException):
+            ops.get_arbitrage_threshold()
+
+    def test_set_failure_wraps_as_dependency_exception(self, redis_ops):
+        ops, client, logger = redis_ops
+        original = Exception("boom")
+        client.set.side_effect = original
+        with pytest.raises(DependencyException) as exc_info:
+            ops.set_arbitrage_threshold(Decimal("0.0042"))
+        assert exc_info.value.__cause__ is original
+
+    def test_get_failure_wraps_as_dependency_exception(self, redis_ops):
+        assert_wraps_as_dependency_exception(
+            redis_ops,
+            FailureSpec(client_attr="get", op_name="get_arbitrage_threshold"),
+        )


### PR DESCRIPTION
## 背景
CEA #318「每日动态套利阈值」的依赖项。premium 日报分析器算出推荐阈值后，需经 Redis 传给在跑的 `realtime_compute_premium`。现有 `set/get_target_premium` 是按 `client_order_id` 的 per-order key，不适用于全局单值阈值。

## 改动
- `RedisOperations.set_arbitrage_threshold(value)` / `get_arbitrage_threshold()`：单 key `arbitrage_threshold`，仿 `set_target_premium` 的 lock + `DependencyException` 封装；读不到返回 `None`，非法值抛 `DataTypeException`。
- 新增 `RedisFields.arbitrage_threshold`。
- TTL = 2 天（容忍单次日报失败不丢阈值）。

## 测试
`tests/test_redis_operations.py::TestArbitrageThreshold` 覆盖 set 写值+过期 / get round-trip / 缺失返回 None / 非法值 / set+get 失败封装。

```
docker run --rm python:3.11 ... pytest tests/test_redis_operations.py
# => 17 passed
```

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)