### PR TITLE
feat(types): 增加 Database.arbitrage_threshold collection 枚举

### DIFF
--- a/pytradekit/utils/static_types.py
+++ b/pytradekit/utils/static_types.py
@@ -52,6 +52,7 @@ class Database(Enum):
     premium_snapshots = auto()
     funding_rate_history = auto()
     balance_pnl_snapshots = auto()
+    arbitrage_threshold = auto()
 
 
 class OrderAttribute(Enum):


### PR DESCRIPTION
## 背景
CEA 要在只读监控 webui 上展示「昨天 / 今天采用的 premium threshold」。每日动态阈值决策需持久化到 `arbitrage` DB 一个新 collection，webui（read-only Mongo 用户，role read on arbitrage）即可读取。

## 改动
`Database` 枚举新增 `arbitrage_threshold` 成员（collection 名）。一行，无逻辑变更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)