### PR TITLE
feat(ws): WS-API user-data 订阅客户端（Ed25519 session）(#83)

### DIFF
--- a/pytradekit/ws/binance_ws_api.py
+++ b/pytradekit/ws/binance_ws_api.py
@@ -1,0 +1,173 @@
+"""Binance WebSocket API user-data subscription client (session-based, Ed25519).
+
+Replaces the deprecated listenKey model (`userDataStream.start/ping/stop`) with
+`session.logon` + `userDataStream.subscribe` on wss://ws-api.binance.com
+(see pytradekit#83). Events delivered on this channel carry the same payloads
+as the legacy user-data stream (executionReport, outboundAccountPosition, ...).
+
+Shadow mode: when running in parallel with the legacy stream, set shadow=True so
+events are only counted and debug-logged — never pushed to the business queue —
+to avoid double-processing during the observation window.
+"""
+import base64
+import json
+import threading
+from urllib.parse import urlencode
+
+import websocket
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from pytradekit.utils.time_handler import get_timestamp_ms
+
+WS_API_URL = 'wss://ws-api.binance.com:443/ws-api/v3'
+RECONNECT_DELAY_S = 5
+PING_INTERVAL_S = 180
+
+LOGON_ID = 'logon'
+SUBSCRIBE_ID = 'subscribe'
+
+
+class Ed25519RequestSigner:
+    """Sign WS-API request params with an Ed25519 private key (PEM)."""
+
+    def __init__(self, private_key_pem: bytes):
+        key = serialization.load_pem_private_key(private_key_pem, password=None)
+        if not isinstance(key, Ed25519PrivateKey):
+            raise ValueError("private key is not Ed25519")
+        self._key = key
+
+    @classmethod
+    def from_file(cls, path: str) -> "Ed25519RequestSigner":
+        with open(path, 'rb') as f:
+            return cls(f.read())
+
+    def sign(self, params: dict) -> str:
+        """Return base64 signature over the alphabetically-sorted query string."""
+        payload = urlencode(sorted(params.items()))
+        return base64.b64encode(self._key.sign(payload.encode('ascii'))).decode('ascii')
+
+
+class BinanceWsApiUserData:
+    """Session-based user-data subscription over the Binance WebSocket API.
+
+    Lifecycle: connect -> session.logon (Ed25519) -> userDataStream.subscribe ->
+    events flow on the same connection. On disconnect, reconnects and re-logons.
+    """
+
+    def __init__(self, logger, api_key: str, signer: Ed25519RequestSigner,
+                 queue=None, on_event=None, shadow: bool = False, url: str = WS_API_URL):
+        self.logger = logger
+        self._api_key = api_key
+        self._signer = signer
+        self._queue = queue
+        self._on_event = on_event
+        self.shadow = shadow
+        self._url = url
+        self._ws = None
+        self._stop = threading.Event()
+        self._thread = None
+        # shadow/diagnostic counters, keyed by event type ('e' field)
+        self.event_counts: dict = {}
+        self.last_event_ms: int = 0
+        self.subscribed = False
+
+    # ---- request builders (pure, unit-testable) ----
+
+    def build_logon(self) -> dict:
+        params = {
+            'apiKey': self._api_key,
+            'timestamp': get_timestamp_ms(),
+        }
+        params['signature'] = self._signer.sign(params)
+        return {'id': LOGON_ID, 'method': 'session.logon', 'params': params}
+
+    @staticmethod
+    def build_subscribe() -> dict:
+        return {'id': SUBSCRIBE_ID, 'method': 'userDataStream.subscribe'}
+
+    # ---- message handling ----
+
+    def handle_message(self, raw: str):
+        try:
+            msg = json.loads(raw)
+        except (ValueError, TypeError):
+            self.logger.debug(f"ws-api non-json message: {str(raw)[:120]}")
+            return
+        if not isinstance(msg, dict):
+            return
+        if 'id' in msg:
+            self._handle_response(msg)
+            return
+        # user-data events arrive either wrapped as {"event": {...}} or bare
+        event = msg.get('event') if isinstance(msg.get('event'), dict) else msg
+        if isinstance(event, dict) and 'e' in event:
+            self._handle_event(event)
+
+    def _handle_response(self, msg: dict):
+        req_id, status = msg.get('id'), msg.get('status')
+        if req_id == LOGON_ID:
+            if status == 200:
+                self.logger.debug("ws-api session.logon OK, subscribing user data stream")
+                self._send(self.build_subscribe())
+            else:
+                self.logger.warning(f"ws-api session.logon failed: {msg.get('error')}")
+        elif req_id == SUBSCRIBE_ID:
+            if status == 200:
+                self.subscribed = True
+                self.logger.debug("ws-api userDataStream.subscribe OK")
+            else:
+                self.logger.warning(f"ws-api subscribe failed: {msg.get('error')}")
+
+    def _handle_event(self, event: dict):
+        etype = event.get('e', '?')
+        self.event_counts[etype] = self.event_counts.get(etype, 0) + 1
+        self.last_event_ms = get_timestamp_ms()
+        if self.shadow:
+            self.logger.debug(f"ws-api shadow event: {etype} (count={self.event_counts[etype]})")
+            return
+        if self._on_event is not None:
+            self._on_event(event)
+        elif self._queue is not None:
+            self._queue.put(event)
+
+    # ---- connection lifecycle ----
+
+    def _send(self, message: dict):
+        if self._ws is not None:
+            self._ws.send(json.dumps(message))
+
+    def _on_open(self, _ws):
+        self.subscribed = False
+        self.logger.debug("ws-api connection open, sending session.logon")
+        self._send(self.build_logon())
+
+    def _on_close(self, _ws, *args):
+        self.subscribed = False
+        self.logger.debug(f"ws-api connection closed: {args}")
+
+    def _on_error(self, _ws, error):
+        self.logger.debug(f"ws-api error: {error}")
+
+    def _run(self):
+        while not self._stop.is_set():
+            self._ws = websocket.WebSocketApp(
+                self._url,
+                on_open=self._on_open,
+                on_message=lambda _ws, raw: self.handle_message(raw),
+                on_close=self._on_close,
+                on_error=self._on_error,
+            )
+            self._ws.run_forever(ping_interval=PING_INTERVAL_S)
+            if not self._stop.is_set():
+                self.logger.debug(f"ws-api disconnected, reconnecting in {RECONNECT_DELAY_S}s")
+                self._stop.wait(RECONNECT_DELAY_S)
+
+    def start(self):
+        self._thread = threading.Thread(target=self._run, daemon=True, name='bn_ws_api_user_data')
+        self._thread.start()
+
+    def stop(self):
+        self._stop.set()
+        if self._ws is not None:
+            self._ws.close()

--- a/tests/test_binance_ws_api.py
+++ b/tests/test_binance_ws_api.py
@@ -1,0 +1,119 @@
+"""Tests for the WebSocket API user-data subscription client (pytradekit#83)."""
+import base64
+import json
+import queue
+from unittest.mock import Mock
+from urllib.parse import urlencode
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from pytradekit.ws.binance_ws_api import (
+    BinanceWsApiUserData,
+    Ed25519RequestSigner,
+    LOGON_ID,
+    SUBSCRIBE_ID,
+)
+
+
+def _make_signer():
+    key = Ed25519PrivateKey.generate()
+    pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return Ed25519RequestSigner(pem), key.public_key()
+
+
+def _make_client(**kwargs):
+    signer, public = _make_signer()
+    client = BinanceWsApiUserData(logger=Mock(), api_key='test_key', signer=signer, **kwargs)
+    client._send = Mock()
+    return client, public
+
+
+class TestEd25519Signer:
+    def test_signature_verifies_against_public_key(self):
+        signer, public = _make_signer()
+        params = {'timestamp': 1751900000000, 'apiKey': 'abc'}
+        sig = signer.sign(params)
+        payload = urlencode(sorted(params.items()))
+        # raises InvalidSignature if wrong
+        public.verify(base64.b64decode(sig), payload.encode('ascii'))
+
+    def test_payload_uses_alphabetical_order(self):
+        signer, public = _make_signer()
+        sig = signer.sign({'b': '2', 'a': '1'})
+        public.verify(base64.b64decode(sig), b'a=1&b=2')
+
+
+class TestRequestBuilders:
+    def test_build_logon_shape(self):
+        client, public = _make_client()
+        req = client.build_logon()
+        assert req['method'] == 'session.logon'
+        assert req['id'] == LOGON_ID
+        params = req['params']
+        assert params['apiKey'] == 'test_key'
+        assert isinstance(params['timestamp'], int)
+        payload = urlencode(sorted({k: v for k, v in params.items() if k != 'signature'}.items()))
+        public.verify(base64.b64decode(params['signature']), payload.encode('ascii'))
+
+    def test_build_subscribe_shape(self):
+        req = BinanceWsApiUserData.build_subscribe()
+        assert req == {'id': SUBSCRIBE_ID, 'method': 'userDataStream.subscribe'}
+
+
+class TestMessageHandling:
+    def test_logon_ack_triggers_subscribe(self):
+        client, _ = _make_client()
+        client.handle_message(json.dumps({'id': LOGON_ID, 'status': 200, 'result': {}}))
+        sent = client._send.call_args[0][0]
+        assert sent['method'] == 'userDataStream.subscribe'
+
+    def test_logon_failure_does_not_subscribe(self):
+        client, _ = _make_client()
+        client.handle_message(json.dumps({'id': LOGON_ID, 'status': 401, 'error': {'msg': 'bad'}}))
+        client._send.assert_not_called()
+
+    def test_subscribe_ack_sets_flag(self):
+        client, _ = _make_client()
+        assert not client.subscribed
+        client.handle_message(json.dumps({'id': SUBSCRIBE_ID, 'status': 200}))
+        assert client.subscribed
+
+    def test_wrapped_event_unwrapped_and_queued(self):
+        q = queue.Queue()
+        client, _ = _make_client(queue=q)
+        client.handle_message(json.dumps({'event': {'e': 'executionReport', 'X': 'FILLED'}}))
+        assert q.get_nowait() == {'e': 'executionReport', 'X': 'FILLED'}
+        assert client.event_counts == {'executionReport': 1}
+
+    def test_bare_event_handled(self):
+        q = queue.Queue()
+        client, _ = _make_client(queue=q)
+        client.handle_message(json.dumps({'e': 'outboundAccountPosition'}))
+        assert q.get_nowait()['e'] == 'outboundAccountPosition'
+
+    def test_shadow_counts_but_never_queues(self):
+        q = queue.Queue()
+        client, _ = _make_client(queue=q, shadow=True)
+        client.handle_message(json.dumps({'event': {'e': 'executionReport'}}))
+        client.handle_message(json.dumps({'event': {'e': 'executionReport'}}))
+        assert client.event_counts == {'executionReport': 2}
+        assert client.last_event_ms > 0
+        assert q.empty()
+
+    def test_on_event_callback_preferred_over_queue(self):
+        q = queue.Queue()
+        received = []
+        client, _ = _make_client(queue=q, on_event=received.append)
+        client.handle_message(json.dumps({'e': 'balanceUpdate'}))
+        assert received == [{'e': 'balanceUpdate'}]
+        assert q.empty()
+
+    def test_non_json_tolerated(self):
+        client, _ = _make_client()
+        client.handle_message('not json at all')
+        client._send.assert_not_called()


### PR DESCRIPTION
## 背景

pytradekit#83：BN 正在退役 listenKey 模型（legacy REST 端点 2026-03 已 410、当前依赖的 WS-API `userDataStream.start/ping/stop` 同样标记 deprecated）。官方替代是 session 化订阅：`session.logon`（Ed25519 签名）+ `userDataStream.subscribe`，事件在同一连接上推送、payload 与 legacy 流一致。

## 改动

新增 `pytradekit/ws/binance_ws_api.py`（自包含，不动现有 `binance_ws.py`）：

- **`Ed25519RequestSigner`** — 按字母序 query string 构造 payload，Ed25519 签名 base64 输出；支持从 PEM 文件加载
- **`BinanceWsApiUserData`** — 连接生命周期：connect → logon → subscribe → 事件派发；断线自动重连+重登录；事件解包兼容 `{"event": {...}}` 包裹与裸 `{"e": ...}` 两种格式；按事件类型计数（`event_counts` / `last_event_ms`）
- **shadow 模式** — 只计数+debug 日志、不进业务 queue：monitor 并行观察期用，避免与 legacy 流双重处理建重复 trade_record

## 测试

新增 12 条单测（签名可用公钥验证、字母序 payload、logon ack→subscribe 流转、事件解包/入队、shadow 语义、非 JSON 容错）。全量 **145 passed**。

## 后续（同 issue checklist）

- 用户在 BN 后台注册 Ed25519 公钥（密钥对已生成，私钥 root-only 在服务器）
- 实盘探针验证 executionReport 到达
- CEA monitor shadow 并行 7 天 → 切主

Closes 无（#83 待全链路完成后关）

🤖 Generated with [Claude Code](https://claude.com/claude-code)