### PR TITLE
feat(bn): add get_perp_user_trades for per-order commission

### DIFF
--- a/pytradekit/restful/binance_restful.py
+++ b/pytradekit/restful/binance_restful.py
@@ -447,6 +447,25 @@ class BinanceClient:
         datas = self.request(HttpMmthod.GET.name, url, params=params)
         return datas
 
+    def get_perp_user_trades(self, symbol, order_id=None, start_time=None, end_time=None, limit=None):
+        """Account trade list (/fapi/v1/userTrades): per-fill records including
+        `commission` / `commissionAsset`, which allOrders does not return."""
+        params = {}
+        params['symbol'] = symbol
+        if order_id:
+            params['orderId'] = order_id
+        if limit:
+            params['limit'] = limit
+        if start_time:
+            params['startTime'] = start_time
+        if end_time:
+            params['endTime'] = end_time
+
+        url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_perp_user_trades.value,
+                                                params=params)
+        datas = self.request(HttpMmthod.GET.name, url, params=params)
+        return datas
+
     def get_perp_force_order(self, symbol, limit=None, start_time=None, end_time=None):
         params = {}
         params['symbol'] = symbol

--- a/pytradekit/utils/dynamic_types.py
+++ b/pytradekit/utils/dynamic_types.py
@@ -914,6 +914,7 @@ class BinanceAuxiliary(Enum):
     url_perp_last_funding_rate_info = "/fapi/v1/fundingInfo"
     url_perp_ticker_price = '/fapi/v2/ticker/price'
     url_perp_all_order = '/fapi/v1/allOrders'
+    url_perp_user_trades = '/fapi/v1/userTrades'
     url_perp_force_order = '/fapi/v1/forceOrders'
     url_perp_position_risk = '/fapi/v3/positionRisk'
     url_perp_income = '/fapi/v1/income'

--- a/tests/test_binance_restful.py
+++ b/tests/test_binance_restful.py
@@ -64,6 +64,27 @@ def test_bn_1013_other_filter_surfaces_raw_msg():
     assert err not in (MinNotionalException.__name__, LotSizeException.__name__)
 
 
+def test_get_perp_user_trades_builds_params():
+    client = _make_client()
+    captured = {}
+
+    def fake_make_private_url(url_path, params, **kwargs):
+        captured["url_path"] = url_path
+        captured["params"] = dict(params)
+        return f"https://fapi.binance.com{url_path}", params, 0
+
+    client._make_private_url = fake_make_private_url
+    client.request = Mock(return_value=[{"commission": "0.13", "commissionAsset": "USDT"}])
+
+    out = client.get_perp_user_trades("ZECUSDT", order_id=123, limit=50)
+
+    assert captured["url_path"] == "/fapi/v1/userTrades"
+    assert captured["params"]["symbol"] == "ZECUSDT"
+    assert captured["params"]["orderId"] == 123
+    assert captured["params"]["limit"] == 50
+    assert out[0]["commissionAsset"] == "USDT"
+
+
 def test_bn_success_passthrough():
     client = _make_client()
     payload = {"orderId": 123, "status": "FILLED"}


### PR DESCRIPTION
## 背景

CEA 的 trade_records 里 **所有** SHORT_LEG(BN perp).fee 都是 0（近14天 265/265 笔）。原因：BN perp user-data WS 故障（#62）后，perp 腿由 REST 回填（`/fapi/v1/allOrders`），而该接口不返回 commission，导致 PnL 报表系统性低估亏损（约 0.26 U/笔 × 双边）。

## 改动

- `BinanceAuxiliary` 新增 `url_perp_user_trades = '/fapi/v1/userTrades'`
- `BinanceClient.get_perp_user_trades(symbol, order_id=None, start_time=None, end_time=None, limit=None)`：按 orderId 查成交明细，含 `commission` / `commissionAsset`
- 单测：参数构建与 URL 路由

## 下游

CEA PR（backfill_short_leg / backfill_close_leg 用此接口汇总 commission 写入 SHORT_LEG.fee）依赖本 PR 先合并。

🤖 Generated with [Claude Code](https://claude.com/claude-code)