### PR TITLE
feat(bn): add get_perp_klines public endpoint

### DIFF
--- a/pytradekit/restful/binance_restful.py
+++ b/pytradekit/restful/binance_restful.py
@@ -447,6 +447,25 @@ class BinanceClient:
         datas = self.request(HttpMmthod.GET.name, url, params=params)
         return datas
 
+    def get_perp_klines(self, symbol, interval, start_time=None, end_time=None, limit=None):
+        """Public perp klines (/fapi/v1/klines). Times are epoch milliseconds.
+
+        Same payload shape as spot get_klines: list of
+        [openTime, open, high, low, close, volume, closeTime, ...].
+        """
+        params = {RestfulRequestsAttribute.symbol.name: symbol,
+                  RestfulRequestsAttribute.interval.name: interval}
+        if start_time:
+            params[RestfulRequestsAttribute.startTime.name] = start_time
+        if end_time:
+            params[RestfulRequestsAttribute.endTime.name] = end_time
+        if limit:
+            params['limit'] = limit
+        url = self._make_public_url(url_path=BinanceAuxiliary.url_perp_kline.value,
+                                    params=params)
+        datas = self.request(HttpMmthod.GET.name, url, params=params, use_sign=False)
+        return datas
+
     def get_perp_user_trades(self, symbol, order_id=None, start_time=None, end_time=None, limit=None):
         """Account trade list (/fapi/v1/userTrades): per-fill records including
         `commission` / `commissionAsset`, which allOrders does not return."""

--- a/pytradekit/utils/dynamic_types.py
+++ b/pytradekit/utils/dynamic_types.py
@@ -914,6 +914,7 @@ class BinanceAuxiliary(Enum):
     url_perp_last_funding_rate_info = "/fapi/v1/fundingInfo"
     url_perp_ticker_price = '/fapi/v2/ticker/price'
     url_perp_all_order = '/fapi/v1/allOrders'
+    url_perp_kline = '/fapi/v1/klines'
     url_perp_user_trades = '/fapi/v1/userTrades'
     url_perp_force_order = '/fapi/v1/forceOrders'
     url_perp_position_risk = '/fapi/v3/positionRisk'

--- a/tests/test_binance_restful.py
+++ b/tests/test_binance_restful.py
@@ -85,6 +85,31 @@ def test_get_perp_user_trades_builds_params():
     assert out[0]["commissionAsset"] == "USDT"
 
 
+def test_get_perp_klines_builds_public_url():
+    client = _make_client()
+    client._url = "https://fapi.binance.com"
+    captured = {}
+
+    def fake_request(method, url, params=None, use_sign=True):
+        captured["method"] = method
+        captured["url"] = url
+        captured["params"] = dict(params or {})
+        captured["use_sign"] = use_sign
+        return [[1700000000000, "1.0", "1.1", "0.9", "1.05", "100", 1700028799999]]
+
+    client.request = fake_request
+
+    out = client.get_perp_klines("ZECUSDT", "8h", start_time=1700000000000, limit=1000)
+
+    assert "/fapi/v1/klines" in captured["url"]
+    assert captured["params"]["symbol"] == "ZECUSDT"
+    assert captured["params"]["interval"] == "8h"
+    assert captured["params"]["startTime"] == 1700000000000
+    assert captured["params"]["limit"] == 1000
+    assert captured["use_sign"] is False
+    assert out[0][4] == "1.05"
+
+
 def test_bn_success_passthrough():
     client = _make_client()
     payload = {"orderId": 123, "status": "FILLED"}


### PR DESCRIPTION
CEA 回测框架（cross_exchange_arbitrage#458 WS-1）需要 perp 8h K 线在资金费结算点计算 spot-perp basis。镜像 get_klines 实现，公开接口无需签名。附单测。

🤖 Generated with [Claude Code](https://claude.com/claude-code)