### PR TITLE
fix(bn): kline 公开请求查询参数重复导致 -1101

### DIFF
--- a/pytradekit/restful/binance_restful.py
+++ b/pytradekit/restful/binance_restful.py
@@ -285,9 +285,12 @@ class BinanceClient:
             params[RestfulRequestsAttribute.startTime.name] = from_date * 1000
         if to_date:
             params[RestfulRequestsAttribute.endTime.name] = to_date * 1000
+        # Query params are already encoded into the URL by _make_public_url;
+        # passing them again makes requests duplicate them and spot /api/v3
+        # rejects with -1101 "Duplicate values for parameter".
         url = self._make_public_url(url_path=BinanceAuxiliary.url_kline.value,
                                     params=params)
-        datas = self.request(HttpMmthod.GET.name, url, params=params)
+        datas = self.request(HttpMmthod.GET.name, url, use_sign=False)
         return datas
 
     def get_balances(self):
@@ -463,7 +466,7 @@ class BinanceClient:
             params['limit'] = limit
         url = self._make_public_url(url_path=BinanceAuxiliary.url_perp_kline.value,
                                     params=params)
-        datas = self.request(HttpMmthod.GET.name, url, params=params, use_sign=False)
+        datas = self.request(HttpMmthod.GET.name, url, use_sign=False)
         return datas
 
     def get_perp_user_trades(self, symbol, order_id=None, start_time=None, end_time=None, limit=None):

--- a/tests/test_binance_restful.py
+++ b/tests/test_binance_restful.py
@@ -93,7 +93,7 @@ def test_get_perp_klines_builds_public_url():
     def fake_request(method, url, params=None, use_sign=True):
         captured["method"] = method
         captured["url"] = url
-        captured["params"] = dict(params or {})
+        captured["params"] = params
         captured["use_sign"] = use_sign
         return [[1700000000000, "1.0", "1.1", "0.9", "1.05", "100", 1700028799999]]
 
@@ -102,12 +102,34 @@ def test_get_perp_klines_builds_public_url():
     out = client.get_perp_klines("ZECUSDT", "8h", start_time=1700000000000, limit=1000)
 
     assert "/fapi/v1/klines" in captured["url"]
-    assert captured["params"]["symbol"] == "ZECUSDT"
-    assert captured["params"]["interval"] == "8h"
-    assert captured["params"]["startTime"] == 1700000000000
-    assert captured["params"]["limit"] == 1000
+    assert "symbol=ZECUSDT" in captured["url"]
+    assert "interval=8h" in captured["url"]
+    assert "startTime=1700000000000" in captured["url"]
+    assert "limit=1000" in captured["url"]
+    # params must NOT be passed again — requests would duplicate the query
+    # and Binance rejects with -1101 "Duplicate values for parameter".
+    assert captured["params"] is None
     assert captured["use_sign"] is False
     assert out[0][4] == "1.05"
+
+
+def test_get_klines_does_not_duplicate_query_params():
+    client = _make_client()
+    client._url = "https://api.binance.com"
+    captured = {}
+
+    def fake_request(method, url, params=None, use_sign=True):
+        captured["url"] = url
+        captured["params"] = params
+        captured["use_sign"] = use_sign
+        return []
+
+    client.request = fake_request
+    client.get_klines("ZECUSDT", "8h", from_date=1700000000, to_date=1700100000)
+
+    assert "symbol=ZECUSDT" in captured["url"]
+    assert captured["params"] is None
+    assert captured["use_sign"] is False
 
 
 def test_bn_success_passthrough():


### PR DESCRIPTION
spot /api/v3/klines 对重复 query 参数直接 400 (-1101)，导致 get_klines 带 startTime 的调用全部失败（CEA 回测框架踩中）。URL 已含完整 query，去掉重复传参并显式 use_sign=False。附回归单测。

🤖 Generated with [Claude Code](https://claude.com/claude-code)