### PR TITLE
fix(bn): fundingRate/tickerPrice GET 漏传查询参数

### DIFF
--- a/pytradekit/restful/binance_restful.py
+++ b/pytradekit/restful/binance_restful.py
@@ -391,7 +391,10 @@ class BinanceClient:
             params['limit'] = limit
         url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_perp_funding_rate.value,
                                                 params=params, use_sign=False)
-        datas = self.request(HttpMmthod.GET.name, url, use_sign=False)
+        # _make_private_url does NOT embed the query in the URL — dropping
+        # params here silently ignored symbol/limit/startTime and the API
+        # returned the global latest-100 rows for every request.
+        datas = self.request(HttpMmthod.GET.name, url, params=params, use_sign=False)
         return datas
 
     def get_perp_last_funding_rate(self, symbol=None):
@@ -416,7 +419,7 @@ class BinanceClient:
             params['symbol'] = symbol
         url, params, _ = self._make_private_url(url_path=BinanceAuxiliary.url_perp_ticker_price.value,
                                                 params=params, use_sign=False)
-        datas = self.request(HttpMmthod.GET.name, url, use_sign=False)
+        datas = self.request(HttpMmthod.GET.name, url, params=params, use_sign=False)
         return datas
 
     def get_perp_open_interes_hist(self, symbol, period, limit=None, start_time=None, end_time=None):

--- a/tests/test_binance_restful.py
+++ b/tests/test_binance_restful.py
@@ -113,6 +113,42 @@ def test_get_perp_klines_builds_public_url():
     assert out[0][4] == "1.05"
 
 
+def test_get_perp_funding_rate_sends_filter_params():
+    client = _make_client()
+    client._url = "https://fapi.binance.com"
+    client.get_timestamp = lambda: 0
+    captured = {}
+
+    def fake_request(method, url, params=None, use_sign=True):
+        captured["params"] = dict(params or {})
+        return []
+
+    client.request = fake_request
+    client.get_perp_funding_rate(symbol="ZECUSDT", start_time=123, end_time=456, limit=1000)
+
+    # _make_private_url keeps the query OUT of the url; params must be passed
+    # through or the API silently returns the global latest-100 rows.
+    assert captured["params"]["symbol"] == "ZECUSDT"
+    assert captured["params"]["startTime"] == 123
+    assert captured["params"]["endTime"] == 456
+    assert captured["params"]["limit"] == 1000
+
+
+def test_get_perp_ticker_price_sends_symbol_param():
+    client = _make_client()
+    client._url = "https://fapi.binance.com"
+    client.get_timestamp = lambda: 0
+    captured = {}
+
+    def fake_request(method, url, params=None, use_sign=True):
+        captured["params"] = dict(params or {})
+        return {}
+
+    client.request = fake_request
+    client.get_perp_ticker_price(symbol="ZECUSDT")
+    assert captured["params"]["symbol"] == "ZECUSDT"
+
+
 def test_get_klines_does_not_duplicate_query_params():
     client = _make_client()
     client._url = "https://api.binance.com"


### PR DESCRIPTION
get_perp_funding_rate / get_perp_ticker_price 构建了 params 却没传给 request()（_make_private_url 不把 query 嵌进 URL），symbol/limit/时间过滤全部失效：fundingRate 恒返回全市场最近 100 条 —— CEA 回测踩中，**线上 funding_rate_collector 采的历史数据同样被污染**（arbitrage.funding_rate_history 需要清洗重采）。附回归单测。

🤖 Generated with [Claude Code](https://claude.com/claude-code)