### PR TITLE
feat(mongo): shadow_trades 集合读写（CEA paper trading）

### DIFF
--- a/pytradekit/utils/mongodb_operations.py
+++ b/pytradekit/utils/mongodb_operations.py
@@ -1457,6 +1457,32 @@ class MongodbOperations:
         res = self.client[Database.arbitrage.name][Database.trade_records.name].find_one(params)
         return res
 
+    # ====== Shadow Trades (paper trading ledger) ======
+
+    def insert_shadow_trade(self, data):
+        collection_path = CollectionPath(db_name=Database.arbitrage.name,
+                                         collection_name=Database.shadow_trades.name)
+        if isinstance(data, dict) and 'shadow_id' in data:
+            data["_id"] = data['shadow_id']
+        self.insert_data(data, collection_path)
+
+    def update_shadow_trade(self, shadow_id, update_data):
+        update = {'$set': self.get_correct_dict(update_data)}
+        self.client[Database.arbitrage.name][Database.shadow_trades.name].update_one(
+            {'shadow_id': shadow_id}, update)
+
+    def read_shadow_trades(self, status=None, time_span=None, limit=0):
+        params = {}
+        if status:
+            params['status'] = status
+        if time_span:
+            params['entry_time_ms'] = {"$gte": time_span.start, "$lte": time_span.end}
+        cursor = self.client[Database.arbitrage.name][Database.shadow_trades.name].find(
+            params).sort('entry_time_ms', -1)
+        if limit:
+            cursor = cursor.limit(limit)
+        return list(cursor)
+
     # ====== Premium Snapshots ======
 
     def insert_premium_snapshot(self, data):

--- a/pytradekit/utils/static_types.py
+++ b/pytradekit/utils/static_types.py
@@ -50,6 +50,7 @@ class Database(Enum):
     arbitrage = auto()
     trade_records = auto()
     premium_snapshots = auto()
+    shadow_trades = auto()
     funding_rate_history = auto()
     balance_pnl_snapshots = auto()
     arbitrage_threshold = auto()


### PR DESCRIPTION
CEA shadow/paper-trading 模式（cross_exchange_arbitrage#458 WS-2）的台账集合，沿 trade_records 模式：Database.shadow_trades + insert/update/read。138 tests passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)