### PR TITLE
fix(bn): wire recvWindow into signed requests (dead constant, ran on 5000ms default)

### DIFF
--- a/pytradekit/restful/binance_restful.py
+++ b/pytradekit/restful/binance_restful.py
@@ -17,7 +17,10 @@ from pytradekit.utils.exceptions import ExchangeException, MinNotionalException,
 from pytradekit.utils.tools import async_retry_decorator
 from pytradekit.utils.static_types import FeeStructureKey
 
-RECVWINDOW = 6000
+# Signed-request validity window. BN's server default is 5000ms; incident-time
+# latency spikes (retry storms, event-loop congestion) pushed requests past it
+# and hedge orders died with -1021 while positions sat unprotected (CEA #447).
+RECVWINDOW = 10000
 RETRY_TIMES = 10
 RETRY_INTERVAL = 5
 
@@ -197,6 +200,10 @@ class BinanceClient:
 
     def _make_private_url(self, url_path, params, use_sign=True, timestamp=True):
         timestamp1 = self.get_timestamp()
+        if use_sign:
+            # recvWindow must be part of the signed payload; setdefault keeps
+            # per-request overrides possible.
+            params.setdefault('recvWindow', RECVWINDOW)
         params['timestamp'] = timestamp1
         payload = '&'.join([f'{param}={value}' for param, value in params.items()])
         if use_sign:

--- a/tests/test_binance_restful.py
+++ b/tests/test_binance_restful.py
@@ -175,3 +175,43 @@ def test_bn_success_passthrough():
     data, err = _run_request(client)
     assert err is None
     assert data == payload
+
+
+class TestRecvWindow:
+    """Signed requests must carry recvWindow inside the signed payload;
+    unsigned requests must not (BN rejects unknown params on some public
+    endpoints and the constant was previously dead code — requests ran on
+    the 5000ms server default and died with -1021 under latency spikes)."""
+
+    def _client_with_capture(self):
+        client = BinanceClient.__new__(BinanceClient)
+        client.logger = Mock()
+        client._url = "https://api.binance.com"
+        captured = {}
+
+        def fake_hashing(payload):
+            captured['payload'] = payload
+            return "sig"
+
+        client._hashing = fake_hashing
+        return client, captured
+
+    def test_signed_request_includes_recv_window_in_payload(self):
+        from pytradekit.restful.binance_restful import RECVWINDOW
+        client, captured = self._client_with_capture()
+        _, params, _ = client._make_private_url("/api/v3/order", {"symbol": "BTCUSDT"})
+        assert params['recvWindow'] == RECVWINDOW
+        assert f"recvWindow={RECVWINDOW}" in captured['payload']
+        # signature computed over payload that already contains recvWindow
+        assert captured['payload'].index('recvWindow') < captured['payload'].index('timestamp')
+
+    def test_caller_override_is_respected(self):
+        client, captured = self._client_with_capture()
+        _, params, _ = client._make_private_url("/api/v3/order", {"recvWindow": 3000})
+        assert params['recvWindow'] == 3000
+        assert "recvWindow=3000" in captured['payload']
+
+    def test_unsigned_request_has_no_recv_window(self):
+        client, _ = self._client_with_capture()
+        _, params, _ = client._make_private_url("/api/v3/exchangeInfo", {}, use_sign=False)
+        assert 'recvWindow' not in params


### PR DESCRIPTION
## 背景

`RECVWINDOW = 6000` 定义后从未使用，所有 BN 私有请求一直跑在服务端默认 5000ms 上。07-06~08 事故期间延迟尖峰导致对冲单 -1021 失败（`position remains unprotected`，CEA #436/#437/#447）。

## 修改

- 常量提到 10000ms，`_make_private_url` 在签名请求中经 `setdefault` 注入（在 timestamp 之前，签名覆盖 recvWindow）
- 调用方可传 `recvWindow` 覆盖单次请求
- 非签名请求不注入

## 测试

新增 `TestRecvWindow` 3 例（注入+签名覆盖 / 调用方覆盖 / 非签名不注入），全量 141 passed。

Closes halfshade-labs/cross_exchange_arbitrage#447

🤖 Generated with [Claude Code](https://claude.com/claude-code)