### PR TITLE
feat(ws): listenKey-free BN user-data stream via WS-API session subscription (#83)

### DIFF
--- a/pytradekit/ws/binance_ws_api.py
+++ b/pytradekit/ws/binance_ws_api.py
@@ -1,0 +1,240 @@
+"""Binance WS-API session user-data stream (listenKey-free).
+
+Binance is retiring the listenKey model entirely (#83): the WS-API
+``userDataStream.start/ping/stop`` methods are deprecated in favour of a
+session-based subscription — ``session.logon`` with an Ed25519 key, then
+``userDataStream.subscribe`` on the same connection; account events
+(executionReport / outboundAccountPosition / balanceUpdate / ...) are
+delivered as frames on that connection.
+
+Shadow mode runs this channel in parallel with the legacy listenKey
+stream: events are counted and logged but NOT pushed to the business
+queue, so downstream trade recording is not duplicated during the
+observation window. After event counts match the legacy channel, flip
+``shadow=False`` (or construct with the business queue) and retire the
+listenKey stream.
+"""
+import base64
+import json
+import time
+from collections import defaultdict
+from threading import Thread
+
+from cryptography.hazmat.primitives import serialization
+from nacl.signing import SigningKey
+from websocket import WebSocketApp
+
+from pytradekit.utils.time_handler import get_timestamp_ms
+
+WS_API_URL = 'wss://ws-api.binance.com:443/ws-api/v3'
+# run_forever ping keeps intermediaries from dropping the idle connection;
+# Binance also pings server-side every ~20s (websocket-client auto-pongs).
+PING_INTERVAL_S = 180
+PING_TIMEOUT_S = 10
+RECONNECT_BASE_DELAY_S = 1
+RECONNECT_MAX_DELAY_S = 60
+
+
+class BinanceWsApiUserData:
+    """Session-based BN user-data subscriber with reconnect + re-logon.
+
+    Args:
+        logger: standard logger.
+        api_key: BN API key registered with an Ed25519 public key.
+        private_key_pem: the Ed25519 private key in PEM form (same input
+            the REST ``BinanceClient`` takes as ``secret``).
+        passphrase: PEM encryption password, if any.
+        queue: business queue receiving raw event dicts (same payload shape
+            the legacy listenKey stream delivered), ignored in shadow mode.
+        shadow: count/log events only; do not push to ``queue``.
+        account_id: label used in logs only.
+    """
+
+    def __init__(self, logger, api_key, private_key_pem, passphrase=None,
+                 queue=None, shadow=True, account_id=None, url=WS_API_URL):
+        self.logger = logger
+        self._api_key = api_key
+        self._signing_key = self._load_signing_key(private_key_pem, passphrase)
+        self._queue = queue
+        self.shadow = shadow
+        self.account_id = account_id
+        self._url = url
+        self._running = False
+        self._thread = None
+        self._ws = None
+        self._logged_on = False
+        self._subscribed = False
+        self._reconnect_delay = RECONNECT_BASE_DELAY_S
+        self._pending = {}  # request id -> method, to route acks
+        # shadow-comparison counters
+        self.event_counts = defaultdict(int)
+        self.last_event_ms = None
+        self.connected_since_ms = None
+
+    # ── signing ─────────────────────────────────────────────
+
+    @staticmethod
+    def _load_signing_key(private_key_pem, passphrase=None):
+        private_key = serialization.load_pem_private_key(
+            private_key_pem.encode(),
+            password=passphrase.encode() if passphrase else None,
+        )
+        raw = private_key.private_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PrivateFormat.Raw,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        return SigningKey(raw)
+
+    def _sign(self, params):
+        """Ed25519-sign the alphabetically ordered query string, base64 out."""
+        payload = '&'.join(f'{k}={params[k]}' for k in sorted(params))
+        signed = self._signing_key.sign(payload.encode('utf-8')).signature
+        return base64.b64encode(signed).decode('ascii')
+
+    # ── requests ────────────────────────────────────────────
+
+    def _send(self, ws, method, params=None):
+        # BN requires id to match ^[a-zA-Z0-9-_]{1,36}$ — method names contain
+        # dots, so build the id from a sanitized prefix + timestamp.
+        prefix = method.split('.')[-1]
+        request_id = f'{prefix}-{get_timestamp_ms()}'
+        msg = {'id': request_id, 'method': method}
+        if params:
+            msg['params'] = params
+        self._pending[request_id] = method
+        ws.send(json.dumps(msg))
+        return request_id
+
+    def _logon(self, ws):
+        params = {'apiKey': self._api_key, 'timestamp': get_timestamp_ms()}
+        params['signature'] = self._sign(params)
+        self._send(ws, 'session.logon', params)
+
+    # ── callbacks ───────────────────────────────────────────
+
+    def _on_open(self, ws):
+        self.connected_since_ms = get_timestamp_ms()
+        self.logger.debug(f"bn ws-api connected ({self._label()}), logging on")
+        self._logon(ws)
+
+    def _on_message(self, ws, message):
+        try:
+            msg = json.loads(message)
+        except (TypeError, ValueError) as e:
+            self.logger.debug(f"bn ws-api undecodable frame: {e}")
+            return
+        if 'id' in msg:
+            self._handle_ack(ws, msg)
+            return
+        event = self._extract_event(msg)
+        if event is not None:
+            self._dispatch(event)
+
+    def _handle_ack(self, ws, msg):
+        method = self._pending.pop(msg['id'], 'unknown')
+        if msg.get('status') == 200:
+            if method == 'session.logon':
+                self._logged_on = True
+                self._reconnect_delay = RECONNECT_BASE_DELAY_S
+                self.logger.debug(f"bn ws-api session.logon ok ({self._label()})")
+                self._send(ws, 'userDataStream.subscribe')
+            elif method == 'userDataStream.subscribe':
+                self._subscribed = True
+                mode = 'shadow' if self.shadow else 'live'
+                self.logger.info(f"bn ws-api user-data subscribed ({self._label()}, mode={mode})")
+        else:
+            # logon/subscribe rejection is not recoverable on this socket;
+            # close and let the run loop reconnect with backoff.
+            self.logger.debug(f"bn ws-api {method} failed: {msg.get('error')}")
+            ws.close()
+
+    @staticmethod
+    def _extract_event(msg):
+        """Subscription frames arrive as {"event": {...}}; tolerate a raw
+        event dict too so a format drift doesn't silently drop events."""
+        event = msg.get('event')
+        if isinstance(event, dict):
+            return event
+        if 'e' in msg:
+            return msg
+        return None
+
+    def _dispatch(self, event):
+        event_type = event.get('e', 'unknown')
+        self.event_counts[event_type] += 1
+        self.last_event_ms = get_timestamp_ms()
+        if self.shadow:
+            self.logger.debug(
+                f"[shadow] bn ws-api event {event_type} "
+                f"({event.get('s', '')}, total={self.event_counts[event_type]})"
+            )
+            return
+        if self._queue is not None:
+            self._queue.put(event)
+
+    def _on_error(self, _ws, error):
+        self.logger.debug(f"bn ws-api error ({self._label()}): {error}")
+
+    def _on_close(self, _ws, status_code, close_msg):
+        self._logged_on = False
+        self._subscribed = False
+        self.logger.debug(
+            f"bn ws-api closed ({self._label()}): code={status_code} msg={close_msg}"
+        )
+
+    # ── lifecycle ───────────────────────────────────────────
+
+    def _run(self):
+        while self._running:
+            self._ws = WebSocketApp(
+                self._url,
+                on_open=self._on_open,
+                on_message=self._on_message,
+                on_error=self._on_error,
+                on_close=self._on_close,
+            )
+            try:
+                self._ws.run_forever(ping_interval=PING_INTERVAL_S, ping_timeout=PING_TIMEOUT_S)
+            except Exception as e:
+                self.logger.debug(f"bn ws-api run_forever error ({self._label()}): {e}")
+            if not self._running:
+                break
+            time.sleep(self._reconnect_delay)
+            self._reconnect_delay = min(self._reconnect_delay * 2, RECONNECT_MAX_DELAY_S)
+            self.logger.debug(f"bn ws-api reconnecting ({self._label()})")
+
+    def start(self):
+        if self._running:
+            return
+        self._running = True
+        self._thread = Thread(target=self._run, daemon=True, name='bn-ws-api-user-data')
+        self._thread.start()
+
+    def stop(self):
+        self._running = False
+        if self._ws is not None:
+            try:
+                self._ws.close()
+            except Exception as e:
+                self.logger.debug(f"bn ws-api close error: {e}")
+
+    # ── observability ───────────────────────────────────────
+
+    def is_healthy(self):
+        return self._logged_on and self._subscribed
+
+    def stats(self):
+        """Snapshot for shadow-vs-legacy event count comparison."""
+        return {
+            'account_id': self.account_id,
+            'shadow': self.shadow,
+            'logged_on': self._logged_on,
+            'subscribed': self._subscribed,
+            'connected_since_ms': self.connected_since_ms,
+            'last_event_ms': self.last_event_ms,
+            'event_counts': dict(self.event_counts),
+        }
+
+    def _label(self):
+        return self.account_id or 'BN'

--- a/tests/test_binance_ws_api.py
+++ b/tests/test_binance_ws_api.py
@@ -1,0 +1,165 @@
+"""Tests for the listenKey-free BN WS-API user-data subscriber (#83).
+
+Covers the issue checklist: Ed25519 signing, message unpacking (acks vs
+event frames), and shadow-mode dispatch isolation.
+"""
+import base64
+import json
+import queue
+from unittest.mock import Mock
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from nacl.signing import VerifyKey
+
+from pytradekit.ws.binance_ws_api import BinanceWsApiUserData
+
+
+def _make_keypair_pem():
+    private_key = Ed25519PrivateKey.generate()
+    pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    public_raw = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    return pem, public_raw
+
+
+def _make_client(shadow=True, business_queue=None):
+    pem, public_raw = _make_keypair_pem()
+    client = BinanceWsApiUserData(
+        logger=Mock(), api_key='test-key', private_key_pem=pem,
+        queue=business_queue, shadow=shadow, account_id='BN_TEST',
+    )
+    return client, public_raw
+
+
+class FakeWs:
+    def __init__(self):
+        self.sent = []
+        self.closed = False
+
+    def send(self, raw):
+        self.sent.append(json.loads(raw))
+
+    def close(self):
+        self.closed = True
+
+
+class TestSigning:
+    def test_signature_verifies_over_sorted_payload(self):
+        client, public_raw = _make_client()
+        params = {'timestamp': 1783680000000, 'apiKey': 'test-key'}
+        signature = client._sign(params)
+        payload = 'apiKey=test-key&timestamp=1783680000000'
+        VerifyKey(public_raw).verify(payload.encode(), base64.b64decode(signature))
+
+    def test_logon_request_contains_signed_params(self):
+        client, public_raw = _make_client()
+        ws = FakeWs()
+        client._logon(ws)
+        msg = ws.sent[0]
+        assert msg['method'] == 'session.logon'
+        params = msg['params']
+        assert params['apiKey'] == 'test-key'
+        payload = f"apiKey={params['apiKey']}&timestamp={params['timestamp']}"
+        VerifyKey(public_raw).verify(payload.encode(), base64.b64decode(params['signature']))
+
+
+class TestSessionFlow:
+    def test_logon_ack_triggers_subscribe(self):
+        client, _ = _make_client()
+        ws = FakeWs()
+        client._logon(ws)
+        logon_id = ws.sent[0]['id']
+        client._on_message(ws, json.dumps({'id': logon_id, 'status': 200, 'result': {}}))
+        assert client._logged_on
+        assert ws.sent[1]['method'] == 'userDataStream.subscribe'
+
+    def test_subscribe_ack_marks_healthy(self):
+        client, _ = _make_client()
+        ws = FakeWs()
+        client._logon(ws)
+        client._on_message(ws, json.dumps({'id': ws.sent[0]['id'], 'status': 200}))
+        client._on_message(ws, json.dumps({'id': ws.sent[1]['id'], 'status': 200}))
+        assert client.is_healthy()
+
+    def test_rejected_logon_closes_socket_for_reconnect(self):
+        client, _ = _make_client()
+        ws = FakeWs()
+        client._logon(ws)
+        client._on_message(ws, json.dumps(
+            {'id': ws.sent[0]['id'], 'status': 401, 'error': {'code': -2015, 'msg': 'invalid key'}}
+        ))
+        assert ws.closed
+        assert not client._logged_on
+
+    def test_close_resets_session_state(self):
+        client, _ = _make_client()
+        client._logged_on = True
+        client._subscribed = True
+        client._on_close(None, 1006, 'abnormal')
+        assert not client.is_healthy()
+
+
+class TestEventUnpacking:
+    def test_wrapped_event_frame(self):
+        client, _ = _make_client()
+        frame = {'event': {'e': 'executionReport', 's': 'BTCUSDT'}}
+        assert BinanceWsApiUserData._extract_event(frame)['e'] == 'executionReport'
+
+    def test_raw_event_dict_tolerated(self):
+        assert BinanceWsApiUserData._extract_event({'e': 'balanceUpdate'})['e'] == 'balanceUpdate'
+
+    def test_non_event_frame_ignored(self):
+        assert BinanceWsApiUserData._extract_event({'result': None}) is None
+
+    def test_undecodable_frame_does_not_raise(self):
+        client, _ = _make_client()
+        client._on_message(FakeWs(), 'not-json')
+
+
+class TestShadowDispatch:
+    def test_shadow_counts_but_never_touches_queue(self):
+        business_queue = queue.Queue()
+        client, _ = _make_client(shadow=True, business_queue=business_queue)
+        client._on_message(FakeWs(), json.dumps(
+            {'event': {'e': 'executionReport', 's': 'ETHUSDT'}}
+        ))
+        assert client.event_counts['executionReport'] == 1
+        assert client.last_event_ms is not None
+        assert business_queue.empty()
+
+    def test_live_mode_pushes_raw_event_to_queue(self):
+        business_queue = queue.Queue()
+        client, _ = _make_client(shadow=False, business_queue=business_queue)
+        event = {'e': 'executionReport', 's': 'ETHUSDT', 'X': 'FILLED'}
+        client._on_message(FakeWs(), json.dumps({'event': event}))
+        assert business_queue.get_nowait() == event
+        assert client.event_counts['executionReport'] == 1
+
+    def test_stats_snapshot_for_channel_comparison(self):
+        client, _ = _make_client(shadow=True)
+        client._on_message(FakeWs(), json.dumps({'event': {'e': 'executionReport'}}))
+        client._on_message(FakeWs(), json.dumps({'event': {'e': 'balanceUpdate'}}))
+        stats = client.stats()
+        assert stats['shadow'] is True
+        assert stats['event_counts'] == {'executionReport': 1, 'balanceUpdate': 1}
+        assert stats['account_id'] == 'BN_TEST'
+
+
+class TestRequestIdFormat:
+    def test_request_id_matches_bn_constraint(self):
+        """Live probe caught -1135: ids must match ^[a-zA-Z0-9-_]{1,36}$
+        (method names contain dots and must not leak into the id)."""
+        import re
+        client, _ = _make_client()
+        ws = FakeWs()
+        client._logon(ws)
+        client._send(ws, 'userDataStream.subscribe')
+        for sent in ws.sent:
+            assert re.fullmatch(r'[a-zA-Z0-9-_]{1,36}', sent['id']), sent['id']


### PR DESCRIPTION
## 背景

#83：listenKey 模型整体退役中。本 PR 落地新通道核心：`session.logon`（Ed25519 签名）→ `userDataStream.subscribe`，账户事件直接以 frame 形式到达同一连接，无 listenKey 生命周期。

## 实现

`pytradekit/ws/binance_ws_api.py` — `BinanceWsApiUserData`：
- **shadow 模式**：只计数/记 debug 日志，不进业务 queue —— 与 legacy listenKey 流并行观察期间不会双重建 trade_record；`stats()` 暴露事件计数用于双通道对比
- **断线重连**：指数退避（1s→60s），每次重连自动重新 logon+subscribe；logon/subscribe 被拒时关闭 socket 进重试循环
- 签名与 REST 客户端同源（PEM → raw → nacl SigningKey，参数按字母序拼串）
- 请求 id 消毒为 `^[a-zA-Z0-9-_]{1,36}$`（实盘探针抓到 -1135：method 名里的点不能进 id）

## 验证

- 单测 14 例（签名可验证性 / logon→subscribe 状态机 / 拒绝重连 / 事件解包双格式 / shadow 隔离 / id 格式回归），全量 155 passed
- **实盘探针（BN_000, shadow）**：`session.logon ok → user-data subscribed, HEALTHY: True`

## 后续（不在本 PR）

- CEA monitor 以 shadow 并行接入观察 7 天，对比事件计数后切主
- executionReport 到达验证将在观察期内随真实成交自然完成

Refs #83, #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)