### PR TITLE
fix(bn): async cancel_order dropped API key header; perp cancel hit spot path

### DIFF
--- a/pytradekit/restful/binance_restful.py
+++ b/pytradekit/restful/binance_restful.py
@@ -640,10 +640,17 @@ class BinanceClient:
             params['orderId'] = order_id
         if client_order_id:
             params['origClientOrderId'] = client_order_id
-        url, params, timestamp = self._make_private_url(url_path=BinanceAuxiliary.url_order.value,
+        url, params, timestamp = self._make_private_url(url_path=self._cancel_order_path(),
                                                         params=params)
-        datas, err = await self.async_request(HttpMmthod.DELETE.name, url, http_client, params=params)
+        # http_client must be passed by keyword: positionally it lands in
+        # use_sign, dropping the X-MBX-APIKEY header (-2014 on every cancel).
+        datas, err = await self.async_request(HttpMmthod.DELETE.name, url,
+                                              http_client=http_client, params=params)
         return datas, err, timestamp
+
+    @staticmethod
+    def _cancel_order_path():
+        return BinanceAuxiliary.url_order.value
 
     def restful_place_market_order(self, symbol, client_order_id, side, volume):
         params = {'symbol': symbol, 'side': side, 'type': 'MARKET',
@@ -745,6 +752,12 @@ class BinancePerpClient(BinanceClient):
     def __init__(self, logger, key=None, secret=None, passphrase=None, account_id=None):
         super().__init__(logger, key, secret, passphrase, account_id)
         self._url = BinanceAuxiliary.perp_url.value
+
+    @staticmethod
+    def _cancel_order_path():
+        # Inherited cancel_order previously hit the spot path (/api/v3/order)
+        # against the fapi base URL — every perp cancel was doomed.
+        return BinanceAuxiliary.url_perp_order.value
 
     def set_leverage(self, symbol, leverage):
         """

--- a/tests/test_binance_restful.py
+++ b/tests/test_binance_restful.py
@@ -215,3 +215,45 @@ class TestRecvWindow:
         client, _ = self._client_with_capture()
         _, params, _ = client._make_private_url("/api/v3/exchangeInfo", {}, use_sign=False)
         assert 'recvWindow' not in params
+
+
+class TestCancelOrderWiring:
+    """Live probe on 2026-07-10 caught -2014 on every async cancel:
+    http_client was passed positionally into use_sign, dropping the
+    X-MBX-APIKEY header; and the inherited perp cancel hit the spot
+    path against the fapi base. Same bug family as #87/#88."""
+
+    def _wire(self, client):
+        client._url = "https://example"
+        client._hashing = lambda payload: "sig"
+        captured = {}
+
+        async def fake_async_request(method, url, use_sign=True, http_client=None, params=None):
+            captured.update(method=method, url=url, use_sign=use_sign, params=params)
+            return {"status": "CANCELED"}, None
+
+        client.async_request = fake_async_request
+        return captured
+
+    def test_spot_cancel_keeps_api_key_header(self):
+        client = _make_client()
+        captured = self._wire(client)
+        asyncio.new_event_loop().run_until_complete(
+            client.cancel_order("BTCUSDT", client_order_id="cid-1")
+        )
+        assert captured['use_sign'] is True
+        assert captured['method'] == 'DELETE'
+        assert '/api/v3/order' in captured['url']
+
+    def test_perp_cancel_uses_fapi_path(self):
+        from pytradekit.restful.binance_restful import BinancePerpClient
+        client = BinancePerpClient.__new__(BinancePerpClient)
+        client.logger = Mock()
+        client.api_key = "k"
+        captured = self._wire(client)
+        asyncio.new_event_loop().run_until_complete(
+            client.cancel_order("DOGEUSDT", order_id=123)
+        )
+        assert captured['use_sign'] is True
+        assert '/fapi/v1/order' in captured['url']
+        assert captured['params']['orderId'] == 123


### PR DESCRIPTION
## 背景

今天做 #83 探针单时实测发现：现货撤单走 async 路径直接 401 `-2014 API-key format invalid`（探针里换同步路径才撤掉）。

## 两个 bug（同一条撤单路径）

1. **`cancel_order` 丢鉴权头**：`async_request(DELETE, url, http_client, params=...)` 第三个位置参数落在 `use_sign` 上 → `use_sign=None` → 不带 `X-MBX-APIKEY` → 每一次 async 撤单必 401。改为 keyword 传参。
2. **perp 撤单打错端点**：`BinancePerpClient` 继承的 cancel_order 用 spot 的 `/api/v3/order` 拼在 fapi base 上。新增 `_cancel_order_path()` 钩子，perp 覆盖为 `/fapi/v1/order`。

## 影响面

CEA `order_executor` 的 `_cancel_perp` / `_cancel_spot_limit_bn`（liq_hedge 撤单路径）两处都踩中——目前是**潜伏态**（日志核查无历史触发），一旦 liq_hedge 需要撤未成交对冲单就会失败、单子滞留。#87/#88 同族 bug（构建了参数但接线错误）。

## 测试

新增 `TestCancelOrderWiring` 2 例（use_sign 保持 True / perp 走 fapi 路径），全量 157 passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)