### PR TITLE
feat: add Binance wire-format order enums to dynamic_types

### DIFF
--- a/pytradekit/utils/dynamic_types.py
+++ b/pytradekit/utils/dynamic_types.py
@@ -871,6 +871,38 @@ class OrderSide(Enum):
     sell = 'S'
 
 
+class BinanceOrderSide(Enum):
+    """Binance API wire values for order side.
+
+    Distinct from :class:`OrderSide` ('B'/'S'), which is the internal
+    storage format — these values go into request params / come back in
+    API responses and must match Binance exactly.
+    """
+    BUY = 'BUY'
+    SELL = 'SELL'
+
+
+class BinanceOrderType(Enum):
+    """Binance API wire values for order type (request param ``type``)."""
+    MARKET = 'MARKET'
+    LIMIT = 'LIMIT'
+    LIMIT_MAKER = 'LIMIT_MAKER'
+
+
+class BinanceOrderStatus(Enum):
+    """Binance API wire values for order status (response field ``status``).
+
+    Distinct from :class:`OrderStatus` ('FULLY_FILLED'/'CANCELLED' —
+    note the double L), which is the internal storage format.
+    """
+    NEW = 'NEW'
+    PARTIALLY_FILLED = 'PARTIALLY_FILLED'
+    FILLED = 'FILLED'
+    CANCELED = 'CANCELED'
+    REJECTED = 'REJECTED'
+    EXPIRED = 'EXPIRED'
+
+
 class WebsocketStatus(Enum):
     ACTIVE = auto()
     SUSPENDED = auto()

--- a/tests/test_binance_wire_enums.py
+++ b/tests/test_binance_wire_enums.py
@@ -1,0 +1,36 @@
+"""Binance wire-format enums must match the exchange API exactly and stay
+distinct from the internal-storage enums (OrderSide 'B'/'S',
+OrderStatus 'CANCELLED' double-L)."""
+from pytradekit.utils.dynamic_types import (
+    BinanceOrderSide,
+    BinanceOrderType,
+    BinanceOrderStatus,
+    OrderSide,
+    OrderStatus,
+)
+
+
+class TestBinanceWireValues:
+
+    def test_side_wire_values(self):
+        assert BinanceOrderSide.BUY.value == 'BUY'
+        assert BinanceOrderSide.SELL.value == 'SELL'
+
+    def test_type_wire_values(self):
+        assert BinanceOrderType.MARKET.value == 'MARKET'
+        assert BinanceOrderType.LIMIT.value == 'LIMIT'
+        assert BinanceOrderType.LIMIT_MAKER.value == 'LIMIT_MAKER'
+
+    def test_status_wire_values_single_l_canceled(self):
+        # Binance spells it CANCELED; the internal enum spells CANCELLED.
+        assert BinanceOrderStatus.CANCELED.value == 'CANCELED'
+        assert OrderStatus.cancelled.value == 'CANCELLED'
+
+    def test_wire_and_internal_side_values_differ(self):
+        assert BinanceOrderSide.BUY.value != OrderSide.buy.value
+        assert BinanceOrderSide.SELL.value != OrderSide.sell.value
+
+    def test_status_members_cover_binance_lifecycle(self):
+        assert {m.name for m in BinanceOrderStatus} == {
+            'NEW', 'PARTIALLY_FILLED', 'FILLED', 'CANCELED', 'REJECTED', 'EXPIRED',
+        }


### PR DESCRIPTION
## 背景

CEA #432/#413 指出 `execution/types.py` 自建 OrderSide/OrderType/OrderStatus。但那三个枚举是 **BN API 线上格式**（`BUY`/`SELL`、`CANCELED` 单 L、`LIMIT_MAKER`），与 pytradekit 内部存储枚举（`'B'/'S'`、`'CANCELLED'` 双 L）值不同，不能直接替换。按「新增类型放 pytradekit」规范上移到这里，业务项目改为导入。

## 改动

- `dynamic_types.py` 新增 `BinanceOrderSide` / `BinanceOrderType` / `BinanceOrderStatus`，docstring 标明与内部枚举的区别
- 新增 `tests/test_binance_wire_enums.py`（5 用例，含 CANCELED/CANCELLED 拼写差异断言），162 全过

配套 CEA PR 将把 `execution/types.py` 改为从这里导入并重导出。

🤖 Generated with [Claude Code](https://claude.com/claude-code)