### PR TITLE
fix: set_portfolios merges into stored snapshot and adds TTL

### DIFF
--- a/pytradekit/utils/redis_operations.py
+++ b/pytradekit/utils/redis_operations.py
@@ -19,6 +19,9 @@ ORDER_TICKER_EXPIRE_TIME = TimeConvert.MIN_TO_S * 30
 ORDERS_EXPIRE_TIME = TimeConvert.MIN_TO_S * 60
 PREMIUM_EXPIRE_TIME = TimeConvert.MIN_TO_S * 60 * 24 * 30
 ORDER_LINK_EXPIRE_TIME = TimeConvert.DAY_TO_S
+# Merged portfolios snapshot for close-side premium checks; per-tick freshness
+# is validated by the reader, TTL only prevents an eternally stale key.
+PORTFOLIOS_EXPIRE_TIME = TimeConvert.MIN_TO_S * 60
 # Daily threshold; TTL > 24h so a single missed analyzer run does not drop it
 ARBITRAGE_THRESHOLD_EXPIRE_TIME = TimeConvert.DAY_TO_S * 2
 TIMEOUT_SECOND = 5
@@ -286,13 +289,34 @@ class RedisOperations:
             raise DependencyException(f"Failed to set depth_order_theoretical for {key}") from e
 
     def set_portfolios(self, value):
+        """Merge `value` ({symbol: data}) into the stored portfolios snapshot and
+        publish only the delta.
+
+        The stored key is read by close-side services to evaluate the premium
+        close condition across ALL open positions, so it must accumulate
+        symbols: a plain SET left only the last signalled symbol in the key,
+        silently disabling premium-based closes for every other position
+        (cross_exchange_arbitrage#472). Pub/sub subscribers (arbitrage_executor)
+        still receive just the per-signal delta. The key expires after
+        PORTFOLIOS_EXPIRE_TIME so a quiet market cannot serve an arbitrarily
+        old snapshot forever; per-tick freshness (ts_ms/local_ts) is the
+        reader's responsibility.
+        """
         key = f"{RedisFields.portfolios.name}"
         lock = self.get_lock_for_resource(key)
         try:
             with lock:
-                serialized = json.dumps(value, cls=_DecimalEncoder)
-                self.client.set(key, serialized)
-                self.client.publish(key, serialized)
+                existing_raw = self.client.get(key)
+                try:
+                    merged = json.loads(existing_raw) if existing_raw else {}
+                except (TypeError, ValueError):
+                    merged = {}
+                if not isinstance(merged, dict):
+                    merged = {}
+                merged.update(value)
+                self.client.set(key, json.dumps(merged, cls=_DecimalEncoder))
+                self.client.expire(key, PORTFOLIOS_EXPIRE_TIME)
+                self.client.publish(key, json.dumps(value, cls=_DecimalEncoder))
         except Exception as e:
             self.logger.exception(f"Failed to set portfolios for {key}: {e}")
             raise DependencyException(f"Failed to set portfolios for {key}") from e

--- a/tests/test_redis_operations.py
+++ b/tests/test_redis_operations.py
@@ -106,6 +106,46 @@ class TestGetTargetPremium:
         )
 
 
+class TestSetPortfolios:
+    """CEA#472: the stored key must accumulate symbols (merge), publish only the
+    delta, and carry a TTL so a quiet market cannot serve an eternal snapshot."""
+
+    def test_merges_into_existing_snapshot(self, redis_ops):
+        import json
+        from pytradekit.utils.redis_operations import PORTFOLIOS_EXPIRE_TIME
+        ops, client, _ = redis_ops
+        client.get.return_value = json.dumps({"BTCUSDT": {"short": {"ask": "1"}}})
+
+        ops.set_portfolios({"REUSDT": {"short": {"ask": "2"}}})
+
+        stored = json.loads(client.set.call_args.args[1])
+        assert set(stored) == {"BTCUSDT", "REUSDT"}
+        published = json.loads(client.publish.call_args.args[1])
+        assert set(published) == {"REUSDT"}
+        client.expire.assert_called_once()
+        assert client.expire.call_args.args[1] == PORTFOLIOS_EXPIRE_TIME
+
+    def test_new_value_overwrites_same_symbol(self, redis_ops):
+        import json
+        ops, client, _ = redis_ops
+        client.get.return_value = json.dumps({"REUSDT": {"short": {"ask": "1"}}})
+
+        ops.set_portfolios({"REUSDT": {"short": {"ask": "9"}}})
+
+        stored = json.loads(client.set.call_args.args[1])
+        assert stored["REUSDT"]["short"]["ask"] == "9"
+
+    def test_corrupt_or_missing_existing_starts_fresh(self, redis_ops):
+        import json
+        ops, client, _ = redis_ops
+        client.get.return_value = "not-json"
+
+        ops.set_portfolios({"REUSDT": {"short": {"ask": "2"}}})
+
+        stored = json.loads(client.set.call_args.args[1])
+        assert set(stored) == {"REUSDT"}
+
+
 class TestArbitrageThreshold:
     def test_set_writes_value_and_expiry(self, redis_ops):
         ops, client, _ = redis_ops


### PR DESCRIPTION
## 问题
`set_portfolios` 用整 key SET 覆盖，portfolios key 里永远只剩最后一个触发信号的 symbol，且无 TTL——CEA close_executor 依赖此 key 判断 premium 回归平仓，导致除最后信号 symbol 外的持仓 premium 平仓条件全部失效，旱季还会读到任意陈旧的快照。详见 halfshade-labs/cross_exchange_arbitrage#472。

## 变更
- 存储侧：读出已有快照 → merge `{symbol: data}` 增量 → 写回，加 `PORTFOLIOS_EXPIRE_TIME`（1h）TTL
- 发布侧：pub/sub 仍只发增量，arbitrage_executor 订阅行为不变
- 读侧的逐 tick 新鲜度校验由 CEA close_executor 配套 PR 处理

## 测试
`docker run --rm -v $(pwd):/app -w /app python:3.11 ... pytest`：**165 passed**（新增 merge/同 symbol 覆盖/损坏快照重建 3 个用例）

🤖 Generated with [Claude Code](https://claude.com/claude-code)