### PR TITLE
fix: get_correct_dict converts Decimal inside lists

### DIFF
--- a/pytradekit/utils/mongodb_operations.py
+++ b/pytradekit/utils/mongodb_operations.py
@@ -118,22 +118,24 @@ class MongodbOperations:
         )
 
     def get_correct_dict(self, a_dict) -> dict:
-        new_dict = {}
-        for key1, val1 in a_dict.items():
-            if isinstance(val1, dict):
-                val1 = self.get_correct_dict(val1)
-            if isinstance(val1, np.bool_):
-                val1 = bool(val1)
-            if isinstance(val1, np.int64):
-                val1 = int(val1)
-            if isinstance(val1, np.float64):
-                val1 = float(val1)
-            if isinstance(val1, Decimal):
-                val1 = str(val1)
-            if isinstance(val1, pd.Timedelta):
-                val1 = str(val1)
-            new_dict[key1] = val1
-        return new_dict
+        return {key1: self.get_correct_value(val1) for key1, val1 in a_dict.items()}
+
+    def get_correct_value(self, value):
+        if isinstance(value, dict):
+            return self.get_correct_dict(value)
+        if isinstance(value, (list, tuple)):
+            return [self.get_correct_value(item) for item in value]
+        if isinstance(value, np.bool_):
+            return bool(value)
+        if isinstance(value, np.int64):
+            return int(value)
+        if isinstance(value, np.float64):
+            return float(value)
+        if isinstance(value, Decimal):
+            return str(value)
+        if isinstance(value, pd.Timedelta):
+            return str(value)
+        return value
 
     def log_duplicates(self, df, subset, message):
         duplicate_rows = df[df.duplicated(subset=subset, keep=False)]

--- a/tests/test_mongodb_operations.py
+++ b/tests/test_mongodb_operations.py
@@ -98,6 +98,40 @@ class TestUpdateTradeRecordStripsDecimal:
         # Non-decimal values pass through unchanged
         assert sent_update['$set']['status'] == 'open'
 
+    def test_decimal_inside_list_converted(self, mocker):
+        """get_correct_dict previously only recursed into dicts; Decimal values nested
+        inside lists (e.g. ArbitragePoolsReport.report = list[pool dict]) reached
+        pymongo unconverted and raised `cannot encode object: Decimal(...)`."""
+        ops, mocked_client = self._make_ops(mocker)
+        report_document = {
+            'day': '2026-07-20',
+            'report': [
+                {
+                    'coin': 'BTC',
+                    'short_leg': {
+                        'inst_code': str(InstCode.from_string('BTC-USDT_BN.PERP')),
+                        'price': Decimal('64609.3'),
+                    },
+                    'long_legs': [
+                        {
+                            'inst_code': str(InstCode.from_string('BTC-USDT_OKX.SPOT')),
+                            'price': Decimal('64605.1'),
+                        },
+                    ],
+                },
+            ],
+        }
+        converted = ops.get_correct_dict(report_document)
+        pool = converted['report'][0]
+        assert pool['short_leg']['price'] == '64609.3'
+        assert pool['long_legs'][0]['price'] == '64605.1'
+        assert converted['day'] == '2026-07-20'
+
+    def test_tuple_converted_to_list_with_decimals(self, mocker):
+        ops, _ = self._make_ops(mocker)
+        converted = ops.get_correct_dict({'prices': (Decimal('1.5'), Decimal('2.5'))})
+        assert converted['prices'] == ['1.5', '2.5']
+
     def test_nested_decimal_in_long_leg_converted(self, mocker):
         ops, mocked_client = self._make_ops(mocker)
         # inst_code 通过 InstCode 类构造而非裸字符串，遵守 CLAUDE.md


### PR DESCRIPTION
## 问题

`cross_exchange_arbitrage_main` 每天 00:05 报错，arbitrage pools 报告自 2026-07-17 起连续 4 天未写入 MongoDB：

```
Failed to store arbitrage pools report to MongoDB: cannot encode object: Decimal('64609.3'), of type: <class 'decimal.Decimal'>
```

## 根因

`MongodbOperations.get_correct_dict` 只对嵌套 **dict** 递归转换，不处理 **list**。`ArbitragePoolsReport.to_dict()` 的 `report` 字段是 `list[pool dict]`，每个 pool 的 leg 里含 `Decimal` 价格，这些值原样传给 pymongo，BSON 编码器拒绝裸 `Decimal` 导致插入失败。

## 修复

- 将逐值转换逻辑抽出为 `get_correct_value`，对 `dict` / `list` / `tuple` 递归（tuple 本来就会被 BSON 编码为 array）
- 标量转换规则不变：`Decimal→str`、`np.bool_/int64/float64→原生类型`、`pd.Timedelta→str`
- 读回路径兼容：CEA 侧 `Leg._coerce_decimal` 通过 `Decimal(str(value))` 统一收敛，str 存储可无损往返

## 测试

- 新增回归测试：模拟 arbitrage pools report 实际结构（list 嵌 dict 嵌 Decimal），断言转换为 str
- 新增 tuple → list 转换测试
- Docker (python:3.11) 全量 pytest：**167 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)