### PR TITLE
fix(redis_operations): encode Decimal in set_orders/set_publish_trades

### DIFF
--- a/pytradekit/utils/redis_operations.py
+++ b/pytradekit/utils/redis_operations.py
@@ -108,7 +108,7 @@ class RedisOperations:
         lock = self.get_lock_for_resource(key)
         try:
             with lock:
-                self.client.sadd(key, json.dumps(value))
+                self.client.sadd(key, json.dumps(value, cls=_DecimalEncoder))
                 self.client.expire(key, ORDERS_EXPIRE_TIME)
         except Exception as e:
             self.logger.exception(f"Failed to set orders for {strategy_id}: {e}")
@@ -131,9 +131,9 @@ class RedisOperations:
         lock = self.get_lock_for_resource(key)
         try:
             with lock:
-                self.client.zadd(key, {json.dumps(value): timestamp})
+                self.client.zadd(key, {json.dumps(value, cls=_DecimalEncoder): timestamp})
                 self.client.expire(key, ORDERS_EXPIRE_TIME)
-                self.client.publish(key, json.dumps(value))
+                self.client.publish(key, json.dumps(value, cls=_DecimalEncoder))
         except Exception as e:
             self.logger.exception(f"Failed to set trades for : {e}")
             raise DependencyException("Failed to set trades for ") from e

--- a/tests/test_redis_operations.py
+++ b/tests/test_redis_operations.py
@@ -186,6 +186,19 @@ class TestArbitrageThreshold:
         )
 
 
+class TestSetOrders:
+    """#118: json.dumps must use _DecimalEncoder; order payloads carry Decimal
+    price/qty fields, so a plain json.dumps(value) raised TypeError (swallowed
+    and re-raised as DependencyException) and silently dropped every order."""
+
+    def test_decimal_fields_serialize_as_str(self, redis_ops):
+        import json
+        ops, client, _ = redis_ops
+        ops.set_orders("strat_x", {"price": Decimal("1.5"), "qty": Decimal("0.001")})
+        member = json.loads(client.sadd.call_args.args[1])
+        assert member == {"price": "1.5", "qty": "0.001"}
+
+
 class TestSetPublishTrades:
     """#97: the except clause caught DependencyException, which the client's
     zadd/expire/publish calls never raise, so real client errors escaped
@@ -198,6 +211,17 @@ class TestSetPublishTrades:
         with pytest.raises(DependencyException) as exc_info:
             ops.set_publish_trades({"BTCUSDT": {"side": "B"}}, 1700000000000)
         assert exc_info.value.__cause__ is original
+
+    def test_decimal_fields_serialize_as_str(self, redis_ops):
+        """#119: zadd member and published payload both carry Decimal price
+        fields; without _DecimalEncoder json.dumps raised TypeError."""
+        import json
+        ops, client, _ = redis_ops
+        ops.set_publish_trades({"BTCUSDT": {"price": Decimal("1.5")}}, 1700000000000)
+        member = next(iter(client.zadd.call_args.args[1]))
+        assert json.loads(member) == {"BTCUSDT": {"price": "1.5"}}
+        published = json.loads(client.publish.call_args.args[1])
+        assert published == {"BTCUSDT": {"price": "1.5"}}
 
 
 class TestGetNewBookTicker:


### PR DESCRIPTION
## 问题

`set_orders`（:111）和 `set_publish_trades`（:134/:136）调用 `json.dumps(value)` 时**未传 `cls=_DecimalEncoder`**，而同文件 `set_portfolios`（:320/:322）是带的。订单/成交 payload 的价格、数量字段按规范为 `Decimal`，因此 `json.dumps` 会抛 `TypeError: Object of type Decimal is not JSON serializable`；该异常被方法内 `except Exception` 捕获并重新包成 `DependencyException`，结果是**订单/成交被静默丢弃**。

Closes #118, closes #119

## 改动

- `set_orders` / `set_publish_trades` 三处 `json.dumps` 统一补 `cls=_DecimalEncoder`（Decimal → str），与 `set_portfolios` 写法对齐。
- 新增回归测试 `TestSetOrders::test_decimal_fields_serialize_as_str`、`TestSetPublishTrades::test_decimal_fields_serialize_as_str`：传入含 `Decimal` 的 payload，断言序列化成功且落为字符串。

## 测试

`python:3.11` 容器挂载运行：`tests/test_redis_operations.py` → **27 passed**（含新增 2 条）。

## 影响面

`set_orders` / `set_publish_trades` 仅 `liquidity_provider` 调用（CEA / LM 不涉及），且 LP 当前无 service 运行，故无生产暴露；合入后下次启动 LP 前 `docker compose build --no-cache` 即可生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)