### PR TITLE
fix(redis_operations): replace deprecated hmset with hset(mapping=...)

### DIFF
--- a/pytradekit/utils/redis_operations.py
+++ b/pytradekit/utils/redis_operations.py
@@ -45,7 +45,7 @@ class RedisOperations:
         lock = self.get_lock_for_resource(key)
         try:
             with lock:
-                self.client.hmset(key, value)
+                self.client.hset(key, mapping=value)
                 self.client.expire(key, TICKER_PRICE_EXPIRE_TIME)
         except Exception as e:
             self.logger.exception(f"Failed to set ticker price for {exchange_id}: {e}")
@@ -76,7 +76,7 @@ class RedisOperations:
         lock = self.get_lock_for_resource(key)
         try:
             with lock:
-                self.client.hmset(key, value)
+                self.client.hset(key, mapping=value)
                 self.client.expire(key, ORDER_TICKER_EXPIRE_TIME)
         except Exception as e:
             self.logger.exception(f"Failed to set book ticker for {inst_code}: {e}")

--- a/tests/test_redis_operations.py
+++ b/tests/test_redis_operations.py
@@ -254,3 +254,22 @@ class TestGetOrderLink:
         ops, client, _ = redis_ops
         client.get.return_value = None
         assert ops.get_order_link("spot_xyz") is None
+
+
+class TestHashWritesUseHset:
+    """#112/#113/#117: hmset() is deprecated (removed in redis-py 6.x); hash
+    writes must use hset(key, mapping=...) instead."""
+
+    def test_set_ticker_price_uses_hset_mapping(self, redis_ops):
+        ops, client, _ = redis_ops
+        ops.set_ticker_price("BN", {"BTCUSDT": "1"})
+        client.hset.assert_called_once()
+        assert client.hset.call_args.kwargs["mapping"] == {"BTCUSDT": "1"}
+        client.hmset.assert_not_called()
+
+    def test_set_book_ticker_uses_hset_mapping(self, redis_ops):
+        ops, client, _ = redis_ops
+        ops.set_book_ticker("BTC-USDT_BN.SPOT", {"bid": "1", "ask": "2"})
+        client.hset.assert_called_once()
+        assert client.hset.call_args.kwargs["mapping"] == {"bid": "1", "ask": "2"}
+        client.hmset.assert_not_called()


### PR DESCRIPTION
## 问题

`set_ticker_price`、`set_book_ticker` 用 `client.hmset()` 写 hash。`hmset` 自 redis-py 3.5 起弃用,并在 **redis-py 6.x 被移除**(调用抛 `AttributeError`)。当前运行环境 5.0.1 只 `DeprecationWarning` 不崩,属定时炸弹。

Closes #112, closes #113, closes #117

## 改动

- 两处 `self.client.hmset(key, value)` → `self.client.hset(key, mapping=value)`,5.x 上等价,向前兼容 6.x。
- 新增回归测试 `TestHashWritesUseHset`:断言两方法以 `mapping=` 调用 `hset`,且不再调用 `hmset`。

## 测试

`python:3.11` 容器挂载:`tests/test_redis_operations.py` → **29 passed**(含新增 2 条)。

## 影响面

纯 API 替换,读写行为与 key 结构不变;读取侧 `hgetall` 无需改动。下游均通过 `RedisOperations` 访问 Redis,无裸 `hmset`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
