### PR TITLE
fix(redis_operations): correct misleading log in get_trading_proposal

### DIFF
--- a/pytradekit/utils/redis_operations.py
+++ b/pytradekit/utils/redis_operations.py
@@ -182,8 +182,8 @@ class RedisOperations:
                 data = self.client.get(key)
                 return data
         except Exception as e:
-            self.logger.exception(f"Failed to get inventory for {key}: {e}")
-            raise DependencyException(f"Failed to get inventory for {key}") from e
+            self.logger.exception(f"Failed to get trading proposal for {key}: {e}")
+            raise DependencyException(f"Failed to get trading proposal for {key}") from e
 
     def push_book_ticker(self, exchange_id, value):
         key = f"{RedisFields.book_ticker.name}:{exchange_id}"


### PR DESCRIPTION
`get_trading_proposal` 的 except 块沿用了从 `get_inventory` 复制来的 `"Failed to get inventory"` 文案，而该方法读的是 trading_proposal key，排查 proposal 读取失败时会误导。

纯日志文案修正，无行为变化。

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)
