### PR TITLE
fix(account_usage): make get_account_api passphrase optional (HTX/BN fee client)

### DIFF
--- a/pytradekit/trading_setup/account_usage.py
+++ b/pytradekit/trading_setup/account_usage.py
@@ -34,5 +34,8 @@ class ExchangeApi:
 def get_account_api(config, account_id):
     api_key = encrypt_decrypt(config.private[account_id + '_key'], 'decrypt')
     api_secret = encrypt_decrypt(config.private[account_id + '_secret'], 'decrypt')
-    api_passphrase = encrypt_decrypt(config.private[account_id + '_passphrase'], 'decrypt')
+    # Passphrase is exchange-specific (e.g. OKX); BN/HTX accounts have none, so
+    # read it optionally instead of KeyError-ing on the missing key.
+    raw_passphrase = config.private.get(account_id + '_passphrase')
+    api_passphrase = encrypt_decrypt(raw_passphrase, 'decrypt') if raw_passphrase else None
     return api_key, api_secret, api_passphrase

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -1,0 +1,39 @@
+"""get_account_api must tolerate accounts without a passphrase.
+
+Passphrase is exchange-specific (OKX has one; BN/HTX do not). The previous
+`config.private[account_id + '_passphrase']` raised KeyError for BN/HTX, so
+exchange_fees._create_rest_client returned None and those exchanges silently
+fell back to static fees instead of live API fees.
+"""
+from types import SimpleNamespace
+
+import pytradekit.trading_setup.account_usage as account_usage
+
+
+def _config(private):
+    return SimpleNamespace(private=private)
+
+
+def test_missing_passphrase_returns_none(monkeypatch):
+    monkeypatch.setattr(account_usage, "encrypt_decrypt", lambda value, _mode: value)
+    config = _config({"HTX_000_key": "k", "HTX_000_secret": "s"})
+
+    key, secret, passphrase = account_usage.get_account_api(config, "HTX_000")
+
+    assert (key, secret, passphrase) == ("k", "s", None)
+
+
+def test_present_passphrase_is_decrypted(monkeypatch):
+    monkeypatch.setattr(account_usage, "encrypt_decrypt", lambda value, _mode: value)
+    config = _config({"OKX_000_key": "k", "OKX_000_secret": "s", "OKX_000_passphrase": "p"})
+
+    assert account_usage.get_account_api(config, "OKX_000") == ("k", "s", "p")
+
+
+def test_empty_passphrase_treated_as_none(monkeypatch):
+    monkeypatch.setattr(account_usage, "encrypt_decrypt", lambda value, _mode: value)
+    config = _config({"BN_000_key": "k", "BN_000_secret": "s", "BN_000_passphrase": ""})
+
+    _key, _secret, passphrase = account_usage.get_account_api(config, "BN_000")
+
+    assert passphrase is None


### PR DESCRIPTION
## 问题（生产日志发现）
CEA `main`（trading_pool_and_fee）反复打：`Failed to get API credentials for HTX_000: 'HTX_000_passphrase'`。

`get_account_api` 用 `config.private[account_id + '_passphrase']` 直接索引，对**没有 passphrase 的账户**（passphrase 是交易所特定的——OKX 有，BN/HTX 没有）抛 KeyError。

唯一调用方 `exchange_fees._create_rest_client` 吞掉异常返回 None → `get_fee_rate_from_api` 对 BN/HTX **静默回退到静态 fee**，拿不到实时 API 费率。三家核心里 2 家（BN/HTX）的 fee client 一直建不出来，只有 OKX（有 passphrase）走实时。

## 修复
passphrase 改为可选读取（缺失/空 → None），passphrase-less 账户可正常建 REST client、使用实时费率。key/secret 仍为必需（真缺失应暴露）。

## 测试
新增 `tests/test_account_usage.py`：缺 passphrase→None、有→解密、空串→None。`test_account_usage + test_exchange_fees` **16 passed**。

## 部署影响
影响 CEA `main` 的 fee 计算 / 动态阈值 fee floor（HTX/BN）。合并后 CEA main 镜像需 `build --no-cache`（pytradekit 为 git 依赖）才拾取。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
