### PR TITLE
fix(binance_ws_api): forward only executionReport to business queue (#83 cutover regression)

### DIFF
--- a/pytradekit/ws/binance_ws_api.py
+++ b/pytradekit/ws/binance_ws_api.py
@@ -33,6 +33,10 @@ PING_INTERVAL_S = 180
 PING_TIMEOUT_S = 10
 RECONNECT_BASE_DELAY_S = 1
 RECONNECT_MAX_DELAY_S = 60
+# Only order events carry a clientOrderId and are meant for the order-trade
+# consumer. Account snapshots (outboundAccountPosition / balanceUpdate) must not
+# be forwarded to the business queue, matching the legacy listenKey stream.
+EXECUTION_REPORT_EVENT = 'executionReport'
 
 
 class BinanceWsApiUserData:
@@ -170,7 +174,10 @@ class BinanceWsApiUserData:
                 f"({event.get('s', '')}, total={self.event_counts[event_type]})"
             )
             return
-        if self._queue is not None:
+        # Live: forward only order events to the business queue. Non-order
+        # account snapshots (outboundAccountPosition / balanceUpdate) have no
+        # clientOrderId and would raise KeyError in the order-trade consumer.
+        if self._queue is not None and event_type == EXECUTION_REPORT_EVENT:
             self._queue.put(event)
 
     def _on_error(self, _ws, error):

--- a/tests/test_binance_ws_api.py
+++ b/tests/test_binance_ws_api.py
@@ -142,6 +142,18 @@ class TestShadowDispatch:
         assert business_queue.get_nowait() == event
         assert client.event_counts['executionReport'] == 1
 
+    def test_live_mode_does_not_queue_non_order_events(self):
+        # outboundAccountPosition/balanceUpdate have no clientOrderId and would
+        # KeyError the order-trade consumer; count them but keep them off queue.
+        business_queue = queue.Queue()
+        client, _ = _make_client(shadow=False, business_queue=business_queue)
+        client._on_message(FakeWs(), json.dumps(
+            {'event': {'e': 'outboundAccountPosition'}}
+        ))
+        assert client.event_counts['outboundAccountPosition'] == 1
+        assert client.last_event_ms is not None
+        assert business_queue.empty()
+
     def test_stats_snapshot_for_channel_comparison(self):
         client, _ = _make_client(shadow=True)
         client._on_message(FakeWs(), json.dumps({'event': {'e': 'executionReport'}}))


### PR DESCRIPTION
## 问题（切换回归，本次运行状况排查发现）
pytradekit#83 切 live 后，`_dispatch` 在 live 模式把**所有**账户事件推入 business queue，包括 `outboundAccountPosition` / `balanceUpdate`。这些事件无 `clientOrderId`，CEA monitor 的 `_process_spot_trade_for_exchange` 读 `["c"]` → `KeyError: "c"`（日志 `Missing key in data for BN spot trade: 'c'`），每次下单都触发一次（引擎空转期仅探针触发过 2 次）。

## 修复
legacy listenKey spot 流只转发 `executionReport`；对齐它——live 模式只把 `executionReport` 入队，非订单事件仍计数（stats/通道存活）但不入队，使 WS-API 成为 legacy 的真正 drop-in。

## 测试
新增 `test_live_mode_does_not_queue_non_order_events`；`test_binance_ws_api.py` **15 passed**。

## 部署
合并后 CEA monitor 镜像 `build --no-cache`（pytradekit git 依赖）重建 + 重启。

Refs #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)
