### PR TITLE
fix(huobi): correct get_commission_rate endpoint/param/fields (HTX live fee)

### DIFF
--- a/pytradekit/restful/huobi_restful.py
+++ b/pytradekit/restful/huobi_restful.py
@@ -186,10 +186,12 @@ class HuobiClient:
         try:
             params = {}
             if symbol:
-                params['symbol'] = symbol.lower()
+                # HTX /v2/reference/transact-fee-rate expects `symbols` (plural,
+                # comma-separated); a singular `symbol` returns 2003 missing-field.
+                params['symbols'] = symbol.lower()
             url = HuobiAuxiliary.url_commission_rate.value
             result = self._send_request(url, method=HttpMmthod.GET.name, params=params, use_sign=True)
-            
+
             if result and isinstance(result, dict):
                 if result.get('code') == 200 and 'data' in result:
                     data = result['data']
@@ -199,13 +201,14 @@ class HuobiClient:
                         fee_data = data
                     else:
                         return None
-                    
-                    maker_rate = float(fee_data.get('maker-fee-rate', 0))
-                    taker_rate = float(fee_data.get('taker-fee-rate', 0))
+
+                    # v2 response uses camelCase makerFeeRate/takerFeeRate.
+                    maker_rate = float(fee_data.get('makerFeeRate', 0))
+                    taker_rate = float(fee_data.get('takerFeeRate', 0))
                     return {FeeStructureKey.maker.name: maker_rate, FeeStructureKey.taker.name: taker_rate}
-                elif isinstance(result, dict) and 'maker-fee-rate' in result:
-                    maker_rate = float(result.get('maker-fee-rate', 0))
-                    taker_rate = float(result.get('taker-fee-rate', 0))
+                elif isinstance(result, dict) and 'makerFeeRate' in result:
+                    maker_rate = float(result.get('makerFeeRate', 0))
+                    taker_rate = float(result.get('takerFeeRate', 0))
                     return {FeeStructureKey.maker.name: maker_rate, FeeStructureKey.taker.name: taker_rate}
             return None
         except Exception as e:

--- a/pytradekit/utils/dynamic_types.py
+++ b/pytradekit/utils/dynamic_types.py
@@ -1014,7 +1014,7 @@ class HuobiAuxiliary(Enum):
     url_trades = '/v1/order/matchresults'
     url_spot_order = '/v1/order/orders/place'  # 现货下单API
     url_perp_balance = '/linear-swap-api/v1/swap_balance_valuation'
-    url_commission_rate = '/v2/reference/transact-fee-rate/get'
+    url_commission_rate = '/v2/reference/transact-fee-rate'
     ws_ping_sleep = 1800
     reconnection_time_sleep = 60 * 60 * 2
 

--- a/tests/test_huobi_restful.py
+++ b/tests/test_huobi_restful.py
@@ -1,0 +1,49 @@
+"""HuobiClient.get_commission_rate must hit the correct HTX v2 endpoint.
+
+The previous implementation used `/v2/reference/transact-fee-rate/get` (404),
+a singular `symbol` param (HTX requires `symbols`), and kebab-case response
+fields (`maker-fee-rate`), so it always returned None and callers silently fell
+back to static fees. HTX real fee (0.002) is higher than the static 0.0015, so
+the fee floor was under-estimated.
+"""
+from unittest.mock import MagicMock
+
+from pytradekit.restful.huobi_restful import HuobiClient
+from pytradekit.utils.dynamic_types import HuobiAuxiliary
+from pytradekit.utils.static_types import FeeStructureKey
+
+
+def _bare_client():
+    # __init__ makes a network call (get_accounts); bypass it.
+    client = object.__new__(HuobiClient)
+    client.logger = MagicMock()
+    client._url = HuobiAuxiliary.url.value
+    return client
+
+
+def test_hits_v2_endpoint_with_plural_symbols():
+    client = _bare_client()
+    captured = {}
+
+    def fake_send(url, method=None, params=None, use_sign=None):
+        captured['url'] = url
+        captured['params'] = params
+        return {'code': 200, 'data': [{'symbol': 'btcusdt',
+                                       'makerFeeRate': '0.002', 'takerFeeRate': '0.002'}]}
+
+    client._send_request = fake_send
+    result = client.get_commission_rate('BTCUSDT')
+
+    assert captured['url'] == '/v2/reference/transact-fee-rate'   # no /get suffix
+    assert captured['params'] == {'symbols': 'btcusdt'}           # plural, lowercased
+    assert result == {FeeStructureKey.maker.name: 0.002, FeeStructureKey.taker.name: 0.002}
+
+
+def test_endpoint_constant_has_no_get_suffix():
+    assert HuobiAuxiliary.url_commission_rate.value == '/v2/reference/transact-fee-rate'
+
+
+def test_returns_none_on_error_code():
+    client = _bare_client()
+    client._send_request = lambda *a, **k: {'code': 404, 'message': 'Not Found', 'success': False}
+    assert client.get_commission_rate('btcusdt') is None


### PR DESCRIPTION
## 问题（HTX 静态费率排查，实盘验证）
`HuobiClient.get_commission_rate` 从来拿不到实时费率 → `exchange_fees.get_fee_rate_from_api` 静默回退静态费率。在 BN_000/HTX_000 实盘验证出三处 bug：

| 端点+参数 | 结果 |
|---|---|
| `/v2/reference/transact-fee-rate/get` + `symbol`（原代码）| **404** |
| `/v2/reference/transact-fee-rate` + `symbols`（修复）| **200** ✅ |

1. 端点多了 `/get` 后缀 → 404；
2. 参数 `symbol` 单数 → HTX 要 `symbols` 复数（否则 2003 missing-field）；
3. 解析 `maker-fee-rate`（kebab）→ v2 实为 `makerFeeRate`/`takerFeeRate`（camelCase），即便端点对了也会解析成 0。

## 交易含义（风险方向）
HTX 是核心交易所，一直用静态 **0.0015**，而真实费率是 **0.002**（实盘返回）。静态**低估**真实费率 → HTX fee floor 偏低 → 可能在覆盖不了 0.002 的溢价上开单。修复后取实时费率。

## 字段选择
用 `makerFeeRate`/`takerFeeRate`（标准费率），下游平台币折扣逻辑不变，避免双重折扣。

## 测试
新增 `tests/test_huobi_restful.py`（端点/复数参数/camelCase 解析/错误码→None）。3 passed。

## 部署
合并后 CEA main 镜像 `build --no-cache` 重建；下一日 fee 计算（~00:05）将改用 HTX 实时费率，可核对 fee floor 变化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
