### PR TITLE
fix(mongodb_operations): guard client singleton and reset index flag on close (#132/#133)

### DIFF
--- a/pytradekit/utils/mongodb_operations.py
+++ b/pytradekit/utils/mongodb_operations.py
@@ -75,8 +75,12 @@ class MongodbOperations:
         return decorator
 
     def __init__(self, mongodb_url, logger=None):
+        # Double-checked locking: guard the shared client creation so concurrent
+        # callers don't each build a MongoClient (extra connection pools).
         if MongodbOperations._client is None:
-            MongodbOperations._client = self._create_client(mongodb_url)
+            with MongodbOperations._indexes_lock:
+                if MongodbOperations._client is None:
+                    MongodbOperations._client = self._create_client(mongodb_url)
         self.client = MongodbOperations._client
         self.logger = logger
         with MongodbOperations._indexes_lock:
@@ -194,6 +198,9 @@ class MongodbOperations:
             if self.logger:
                 self.logger.debug("MongoDB connection closed.")
             MongodbOperations._client = None
+            # Reset so a reconnect re-ensures indexes on the new client; the flag
+            # is bound to the connection's lifecycle, not the process.
+            MongodbOperations._indexes_ensured = False
 
     def delete_coll(self, collection_path):
         """

--- a/tests/test_mongodb_operations.py
+++ b/tests/test_mongodb_operations.py
@@ -32,6 +32,25 @@ def test_close(mocker):
     mongodb_operations = MongodbOperations(MONGODB_URL)
     mongodb_operations.close()
     assert MongodbOperations._client is None
+    # #133: the index-ensured flag is bound to the connection lifecycle and must
+    # reset on close so a reconnect re-ensures indexes.
+    assert MongodbOperations._indexes_ensured is False
+
+
+def test_reconnect_after_close_reensures_indexes(mocker):
+    # #132/#133: after close(), a new instance must build a fresh client AND
+    # re-ensure indexes (the flag no longer sticks from the old connection).
+    MongodbOperations._client = None
+    MongodbOperations._indexes_ensured = False
+    mocker.patch('pytradekit.utils.mongodb_operations.MongoClient', return_value=mocker.MagicMock())
+    ensure = mocker.patch.object(MongodbOperations, '_ensure_indexes')
+
+    ops = MongodbOperations(MONGODB_URL)
+    assert ensure.call_count == 1
+
+    ops.close()
+    MongodbOperations(MONGODB_URL)
+    assert ensure.call_count == 2
 
 
 def test_check_connection(mocker):


### PR DESCRIPTION
## #132 — 单例 client 竞态
`__init__` 的 `if _client is None: _client = _create_client(...)` 未加锁，多线程并发可各建一个 MongoClient（多套连接池）。改为在已有的 `_indexes_lock` 下用双重检查锁定。

## #133 — close() 未重置索引标志
`close()` 置 `_client=None` 但保留 `_indexes_ensured=True`。重连时新 client 建好，但 `_ensure_indexes()` 因标志仍为 True 被跳过 → 新连接上索引（如 `funding_rate_history` 唯一键）未建。改为 close() 同步 `_indexes_ensured=False`。

## 测试
扩展 `test_close`（断言标志重置）+ 新增 `test_reconnect_after_close_reensures_indexes`（close 后重连 `_ensure_indexes` 再次调用）。11 passed。

Closes #132, closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)