### PR TITLE
fix(redis_operations): use _DecimalEncoder for all business json.dumps (#120/#114)

### DIFF
--- a/pytradekit/utils/redis_operations.py
+++ b/pytradekit/utils/redis_operations.py
@@ -188,7 +188,7 @@ class RedisOperations:
     def push_book_ticker(self, exchange_id, value):
         key = f"{RedisFields.book_ticker.name}:{exchange_id}"
         try:
-            self.client.publish(key, json.dumps(value))
+            self.client.publish(key, json.dumps(value, cls=_DecimalEncoder))
         except Exception as e:
             self.logger.exception(f"Failed to push data for {key}: {e}")
             raise DependencyException(f"Failed to push data for {key}") from e
@@ -198,8 +198,8 @@ class RedisOperations:
         lock = self.get_lock_for_resource(key)
         try:
             with lock:
-                self.client.set(key, json.dumps(value))
-                self.client.publish(key, json.dumps(value))
+                self.client.set(key, json.dumps(value, cls=_DecimalEncoder))
+                self.client.publish(key, json.dumps(value, cls=_DecimalEncoder))
         except Exception as e:
             self.logger.exception(f"Failed to set profit_loss for {key}: {e}")
             raise DependencyException(f"Failed to set profit_loss for {key}") from e
@@ -209,7 +209,7 @@ class RedisOperations:
         lock = self.get_lock_for_resource(key)
         try:
             with lock:
-                self.client.set(key, json.dumps(value))
+                self.client.set(key, json.dumps(value, cls=_DecimalEncoder))
         except Exception as e:
             self.logger.exception(f"Failed to set trading_proposal for {key}: {e}")
             raise DependencyException(f"Failed to set trading_proposal for {key}") from e
@@ -228,7 +228,7 @@ class RedisOperations:
         lock = self.get_lock_for_resource(key)
         try:
             with lock:
-                self.client.set(key, json.dumps(value))
+                self.client.set(key, json.dumps(value, cls=_DecimalEncoder))
                 self.client.expire(key, ORDER_TICKER_EXPIRE_TIME)
         except Exception as e:
             self.logger.exception(f"Failed to set book ticker for {exchange_id}: {e}")
@@ -272,9 +272,9 @@ class RedisOperations:
         lock = self.get_lock_for_resource(key)
         try:
             with lock:
-                self.client.set(key, json.dumps(value))
+                self.client.set(key, json.dumps(value, cls=_DecimalEncoder))
                 self.client.expire(key, TICKER_PRICE_EXPIRE_TIME)
-                self.client.publish(key, json.dumps(value))
+                self.client.publish(key, json.dumps(value, cls=_DecimalEncoder))
         except Exception as e:
             self.logger.exception(f"Failed to set non_compliant_inst_code for {key}: {e}")
             raise DependencyException(f"Failed to set non_compliant_inst_code for {key}") from e
@@ -284,9 +284,9 @@ class RedisOperations:
         lock = self.get_lock_for_resource(key)
         try:
             with lock:
-                self.client.set(key, json.dumps(value))
+                self.client.set(key, json.dumps(value, cls=_DecimalEncoder))
                 self.client.expire(key, TICKER_PRICE_EXPIRE_TIME)
-                self.client.publish(key, json.dumps(value))
+                self.client.publish(key, json.dumps(value, cls=_DecimalEncoder))
         except Exception as e:
             self.logger.exception(f"Failed to set depth_order_theoretical for {key}: {e}")
             raise DependencyException(f"Failed to set depth_order_theoretical for {key}") from e

--- a/tests/test_redis_operations.py
+++ b/tests/test_redis_operations.py
@@ -273,3 +273,34 @@ class TestHashWritesUseHset:
         client.hset.assert_called_once()
         assert client.hset.call_args.kwargs["mapping"] == {"bid": "1", "ask": "2"}
         client.hmset.assert_not_called()
+
+
+class TestDecimalEncoderConsistency:
+    """#120/#114: every json.dumps of a business value must use _DecimalEncoder;
+    book_ticker / depth / inventory-close payloads carry Decimal price fields and
+    would raise TypeError otherwise."""
+
+    def test_set_new_book_ticker_encodes_decimal(self, redis_ops):
+        import json
+        ops, client, _ = redis_ops
+        ops.set_new_book_ticker("BN", {"bid": Decimal("1.5"), "ask": Decimal("1.6")})
+        assert json.loads(client.set.call_args.args[1]) == {"bid": "1.5", "ask": "1.6"}
+
+    def test_push_book_ticker_encodes_decimal(self, redis_ops):
+        import json
+        ops, client, _ = redis_ops
+        ops.push_book_ticker("BN", {"bid": Decimal("1.5")})
+        assert json.loads(client.publish.call_args.args[1]) == {"bid": "1.5"}
+
+    def test_set_depth_order_theoretical_encodes_decimal(self, redis_ops):
+        import json
+        ops, client, _ = redis_ops
+        ops.set_depth_order_theoretical("BN", {"px": Decimal("2.5")})
+        assert json.loads(client.set.call_args.args[1]) == {"px": "2.5"}
+        assert json.loads(client.publish.call_args.args[1]) == {"px": "2.5"}
+
+    def test_set_publish_inventory_close_encodes_decimal(self, redis_ops):
+        import json
+        ops, client, _ = redis_ops
+        ops.set_publish_inventory_close({"pnl": Decimal("-3.25")})
+        assert json.loads(client.set.call_args.args[1]) == {"pnl": "-3.25"}


### PR DESCRIPTION
## 问题
`redis_operations.py` 还有 9 处 `json.dumps(value)` 未传 `cls=_DecimalEncoder`（`push_book_ticker` / `set_publish_inventory_close` / `set_trading_proposal` / `set_new_book_ticker` / `set_publish_non_compliant_inst_code` / `set_depth_order_theoretical`）。这些 payload 的价格字段若为 `Decimal`，`json.dumps` 会抛 `TypeError`（被 except 包成 `DependencyException`）。

## 修复
全部补 `cls=_DecimalEncoder`，与已修的 `set_orders`/`set_publish_trades`/`set_portfolios` 一致。纯一致性修复：value 不含 Decimal 时输出不变，含 Decimal 时由崩溃变为 str 序列化。

## 测试
新增 `TestDecimalEncoderConsistency`（set_new_book_ticker / push_book_ticker / set_depth_order_theoretical / set_publish_inventory_close 的 Decimal→str）。33 passed。

Closes #120, closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)