### PR TITLE
fix(account_usage): raise DataTypeException on missing required credential (#141)

### DIFF
--- a/pytradekit/trading_setup/account_usage.py
+++ b/pytradekit/trading_setup/account_usage.py
@@ -1,5 +1,6 @@
 from pytradekit.utils.dynamic_types import RunningMode
 from pytradekit.utils.tools import encrypt_decrypt
+from pytradekit.utils.exceptions import DataTypeException
 
 
 
@@ -32,8 +33,13 @@ class ExchangeApi:
 
 
 def get_account_api(config, account_id):
-    api_key = encrypt_decrypt(config.private[account_id + '_key'], 'decrypt')
-    api_secret = encrypt_decrypt(config.private[account_id + '_secret'], 'decrypt')
+    # key/secret are required; surface a domain exception (not a raw KeyError)
+    # so callers catch a single well-defined type, consistent with passphrase.
+    try:
+        api_key = encrypt_decrypt(config.private[account_id + '_key'], 'decrypt')
+        api_secret = encrypt_decrypt(config.private[account_id + '_secret'], 'decrypt')
+    except KeyError as e:
+        raise DataTypeException(f"Missing required credential {e} for account {account_id}") from e
     # Passphrase is exchange-specific (e.g. OKX); BN/HTX accounts have none, so
     # read it optionally instead of KeyError-ing on the missing key.
     raw_passphrase = config.private.get(account_id + '_passphrase')

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -7,7 +7,10 @@ fell back to static fees instead of live API fees.
 """
 from types import SimpleNamespace
 
+import pytest
+
 import pytradekit.trading_setup.account_usage as account_usage
+from pytradekit.utils.exceptions import DataTypeException
 
 
 def _config(private):
@@ -37,3 +40,13 @@ def test_empty_passphrase_treated_as_none(monkeypatch):
     _key, _secret, passphrase = account_usage.get_account_api(config, "BN_000")
 
     assert passphrase is None
+
+
+def test_missing_required_key_raises_data_type_exception(monkeypatch):
+    # #141: a missing key/secret must surface a domain exception, not a raw
+    # KeyError, consistent with the passphrase handling.
+    monkeypatch.setattr(account_usage, "encrypt_decrypt", lambda value, _mode: value)
+    config = _config({"BN_000_secret": "s"})  # no _key
+
+    with pytest.raises(DataTypeException):
+        account_usage.get_account_api(config, "BN_000")


### PR DESCRIPTION
## 问题
#125 让 passphrase 可选处理后，`key`/`secret` 仍用直接字典索引，缺失时抛裸 `KeyError`，与 passphrase 的优雅处理及模块其余的领域异常约定不一致，诊断困难。

## 修复
key/secret 是必需字段，缺失时包裹为 `DataTypeException`（带 account 上下文），使调用方只需捕获单一明确类型。passphrase 保持可选。

## 测试
新增 `test_missing_required_key_raises_data_type_exception`。`test_account_usage + test_exchange_fees` 17 passed。

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)