### PR TITLE
Add runtime bookticker subscription updates

### DIFF
--- a/pytradekit/gateway/websocket/base_ws_manager.py
+++ b/pytradekit/gateway/websocket/base_ws_manager.py
@@ -158,5 +158,5 @@ class BaseWebsocketManager:
 
     def _reconnect_streams(self):
         self.logger.debug("reconnect_streams: ", self._subs)
-        for sub in self._subs:
+        for sub in tuple(self._subs):
             self.send_json(sub)

--- a/pytradekit/gateway/websocket/ws_manager.py
+++ b/pytradekit/gateway/websocket/ws_manager.py
@@ -42,7 +42,7 @@ class WsManager(BaseWebsocketManager):
         super().send_json(msg)
 
     def _reconnect_streams(self):
-        for sub in self._subs:
+        for sub in tuple(self._subs):
             self.send_json(sub)
 
     def _ping(self, n_seconds) -> None:

--- a/pytradekit/ws/binance_ws.py
+++ b/pytradekit/ws/binance_ws.py
@@ -1,6 +1,7 @@
 import time
 import json
 from threading import Thread
+from typing import Iterable, List
 
 import requests
 
@@ -11,6 +12,14 @@ from pytradekit.utils.dynamic_types import SlackUser
 from pytradekit.ws.save_restful_bn_deposit_withdraw import HandleRestfulDepositWithdraw
 from pytradekit.ws.bn_add_missing_orders import get_binance_trade
 from pytradekit.utils.tools import get_redis
+from pytradekit.ws.subscription_update import (
+    SubscriptionUpdate,
+    calculate_subscription_update,
+    normalize_subscription_targets,
+)
+
+
+BINANCE_UNSUBSCRIBE_METHOD = "UNSUBSCRIBE"
 
 
 class AtUser:
@@ -57,6 +66,7 @@ class BinanceWsManager(WsManager):
         self._bn_client = bn_client
         self._mm_symbol_list = mm_symbol_list
         self.verify_bookticker_duplicate = {}
+        self._bookticker_symbols = frozenset()
 
     def _get_api_url(self) -> str:
         return self._api_url
@@ -259,12 +269,46 @@ class BinanceWsManager(WsManager):
         self.start_subscribe(params)
         self._ping(BinanceAuxiliary.ws_ping_sleep.value)
 
-    def start_bookticker_stream(self, symbols):
-        params = []
-        for symbol in symbols:
-            params.append(f'{symbol.lower()}{BinanceAuxiliary.ws_book_ticker.value}')
+    def start_bookticker_stream(self, symbols: Iterable[str]) -> None:
+        target_symbols = normalize_subscription_targets(symbols)
+        params = self._build_bookticker_params(target_symbols)
+        self._bookticker_symbols = target_symbols
         self.start_subscribe(params)
         self._ping(BinanceAuxiliary.ws_ping_sleep.value, is_listen_key=False)
+
+    @staticmethod
+    def _build_bookticker_params(symbols: Iterable[str]) -> List[str]:
+        return [
+            f"{symbol.lower()}{BinanceAuxiliary.ws_book_ticker.value}"
+            for symbol in sorted(symbols)
+        ]
+
+    def update_bookticker_stream(
+        self,
+        symbols: Iterable[str],
+    ) -> SubscriptionUpdate:
+        """Update a live book-ticker stream without reconnecting it."""
+        target_symbols = normalize_subscription_targets(symbols)
+        current_symbols = getattr(self, "_bookticker_symbols", frozenset())
+        update = calculate_subscription_update(current_symbols, target_symbols)
+        if not update.added and not update.removed:
+            return update
+        if update.added:
+            self.send_json({
+                "method": BinanceWebSocket.subscribe.value,
+                "params": self._build_bookticker_params(update.added),
+            })
+        if update.removed:
+            self.send_json({
+                "method": BINANCE_UNSUBSCRIBE_METHOD,
+                "params": self._build_bookticker_params(update.removed),
+            })
+        self._bookticker_symbols = target_symbols
+        self._subs = [{
+            "method": BinanceWebSocket.subscribe.value,
+            "params": self._build_bookticker_params(target_symbols),
+        }]
+        return update
 
     def start_perp_lastprice_stream(self, symbols):
         params = []

--- a/pytradekit/ws/huobi_ws.py
+++ b/pytradekit/ws/huobi_ws.py
@@ -5,11 +5,16 @@ import hashlib
 import urllib.parse
 import gzip
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Iterable, List, Optional
 
 from pytradekit.utils.dynamic_types import HuobiAuxiliary
 from pytradekit.gateway.websocket.ws_manager import WsManager
 from pytradekit.utils.time_handler import get_htx_timestamp, get_timestamp_s, sleep_min_time
+from pytradekit.ws.subscription_update import (
+    SubscriptionUpdate,
+    calculate_subscription_update,
+    normalize_subscription_targets,
+)
 
 
 @dataclass
@@ -44,6 +49,7 @@ class HuobiWsManager(WsManager):
         self._account_id = config.account_id
         self._ws_connected = False
         self.logger = logger
+        self._bookticker_symbols = frozenset()
 
     def get_signature(self, params):
         sorted_params = sorted(params.items(), key=lambda d: d[0], reverse=False)
@@ -95,10 +101,10 @@ class HuobiWsManager(WsManager):
 
     def _send_all_subscriptions(self) -> None:
         """Send all cached subscription requests."""
-        for req in self._subs:
+        for req in tuple(self._subs):
             self.start_subscribe(req)
 
-    def start_bookticker_stream(self, symbol_list):
+    def start_bookticker_stream(self, symbol_list: Iterable[str]) -> None:
         """
         Start Huobi(HTX) spot BBO websocket stream for given symbols.
 
@@ -107,12 +113,9 @@ class HuobiWsManager(WsManager):
         - 逐条发送订阅
         - 定期重订阅保持连接活跃
         """
-        self._subs = []
-
-        for idx, symbol in enumerate(symbol_list, start=1):
-            ch = f"market.{symbol.lower()}.bbo"
-            req = {"sub": ch, "id": idx}
-            self._subs.append(req)
+        target_symbols = normalize_subscription_targets(symbol_list)
+        self._bookticker_symbols = target_symbols
+        self._subs = self._build_bookticker_requests(target_symbols)
 
         self._send_all_subscriptions()
 
@@ -122,6 +125,38 @@ class HuobiWsManager(WsManager):
                 HuobiAuxiliary.reconnection_time_sleep.value,
             )
             self._send_all_subscriptions()
+
+    @staticmethod
+    def _build_bookticker_channel(symbol: str) -> str:
+        return f"market.{symbol.lower()}.bbo"
+
+    @classmethod
+    def _build_bookticker_requests(
+        cls,
+        symbols: Iterable[str],
+    ) -> List[dict]:
+        return [
+            {"sub": cls._build_bookticker_channel(symbol), "id": index}
+            for index, symbol in enumerate(sorted(symbols), start=1)
+        ]
+
+    def update_bookticker_stream(
+        self,
+        symbols: Iterable[str],
+    ) -> SubscriptionUpdate:
+        """Update a live public book-ticker stream in place."""
+        target_symbols = normalize_subscription_targets(symbols)
+        current_symbols = getattr(self, "_bookticker_symbols", frozenset())
+        update = calculate_subscription_update(current_symbols, target_symbols)
+        if not update.added and not update.removed:
+            return update
+        for symbol in update.added:
+            self.send_json({"sub": self._build_bookticker_channel(symbol)})
+        for symbol in update.removed:
+            self.send_json({"unsub": self._build_bookticker_channel(symbol)})
+        self._bookticker_symbols = target_symbols
+        self._subs = self._build_bookticker_requests(target_symbols)
+        return update
 
     def subscribe(self):
         """

--- a/pytradekit/ws/okex_ws.py
+++ b/pytradekit/ws/okex_ws.py
@@ -2,10 +2,16 @@ import time
 import json
 import hmac
 import base64
+from typing import Iterable, List
 
 from pytradekit.utils.dynamic_types import OkexAuxiliary, OkexWebSocket, WebsocketStatus
 from pytradekit.gateway.websocket.ws_manager import WsManager
 from pytradekit.utils.time_handler import get_timestamp_s, get_millisecond_str, get_datetime
+from pytradekit.ws.subscription_update import (
+    SubscriptionUpdate,
+    calculate_subscription_update,
+    normalize_subscription_targets,
+)
 
 
 class OkexWsManager(WsManager):
@@ -29,6 +35,7 @@ class OkexWsManager(WsManager):
         self._account_id = account_id
         self._ws_connected = False
         self.logger = logger
+        self._bookticker_symbols = frozenset()
 
     def get_signature(self, params):
         mac = hmac.new(bytes(self._api_secret, encoding='utf8'), bytes(params, encoding='utf-8'), digestmod='sha256')
@@ -83,15 +90,49 @@ class OkexWsManager(WsManager):
         }
         self.start_subscribe(login_params)
 
-    def start_bookticker_stream(self, symbol_list):
-        arg = []
-        for i in symbol_list:
-            arg.append({'channel': 'tickers', 'instId': i})
-        params = {"op": "subscribe", "args": arg}
+    def start_bookticker_stream(self, symbol_list: Iterable[str]) -> None:
+        target_symbols = normalize_subscription_targets(symbol_list)
+        args = self._build_bookticker_args(target_symbols)
+        params = {"op": "subscribe", "args": args}
+        self._bookticker_symbols = target_symbols
         if params not in self._subs:
             self._subs.append(params)
         self.start_subscribe(params)
         self._ping(20)
+
+    @staticmethod
+    def _build_bookticker_args(symbols: Iterable[str]) -> List[dict]:
+        return [
+            {"channel": "tickers", "instId": symbol}
+            for symbol in sorted(symbols)
+        ]
+
+    def update_bookticker_stream(
+        self,
+        symbols: Iterable[str],
+    ) -> SubscriptionUpdate:
+        """Update a live public book-ticker stream in place."""
+        target_symbols = normalize_subscription_targets(symbols)
+        current_symbols = getattr(self, "_bookticker_symbols", frozenset())
+        update = calculate_subscription_update(current_symbols, target_symbols)
+        if not update.added and not update.removed:
+            return update
+        if update.added:
+            self.send_json({
+                "op": "subscribe",
+                "args": self._build_bookticker_args(update.added),
+            })
+        if update.removed:
+            self.send_json({
+                "op": "unsubscribe",
+                "args": self._build_bookticker_args(update.removed),
+            })
+        self._bookticker_symbols = target_symbols
+        self._subs = [{
+            "op": "subscribe",
+            "args": self._build_bookticker_args(target_symbols),
+        }]
+        return update
 
     def subscribe(self):
         try:

--- a/pytradekit/ws/subscription_update.py
+++ b/pytradekit/ws/subscription_update.py
@@ -1,0 +1,35 @@
+"""Shared types and helpers for runtime WebSocket subscription updates."""
+
+from dataclasses import dataclass
+from typing import FrozenSet, Iterable, Tuple
+
+
+@dataclass(frozen=True)
+class SubscriptionUpdate:
+    """Normalized identifiers added to and removed from a subscription."""
+
+    added: Tuple[str, ...]
+    removed: Tuple[str, ...]
+
+
+def normalize_subscription_targets(values: Iterable[str]) -> FrozenSet[str]:
+    """Normalize subscription identifiers to non-empty uppercase strings."""
+    normalized_values = {
+        str(value).strip().upper()
+        for value in values
+        if str(value).strip()
+    }
+    return frozenset(normalized_values)
+
+
+def calculate_subscription_update(
+    current: Iterable[str],
+    target: Iterable[str],
+) -> SubscriptionUpdate:
+    """Calculate a deterministic subscription update."""
+    current_values = frozenset(current)
+    target_values = frozenset(target)
+    return SubscriptionUpdate(
+        added=tuple(sorted(target_values - current_values)),
+        removed=tuple(sorted(current_values - target_values)),
+    )

--- a/tests/test_bookticker_subscription_updates.py
+++ b/tests/test_bookticker_subscription_updates.py
@@ -1,0 +1,165 @@
+import pytest
+
+from pytradekit.utils.dynamic_types import BinanceWebSocket
+from pytradekit.ws.binance_ws import BinanceWsManager
+from pytradekit.ws.huobi_ws import HuobiWsManager
+from pytradekit.ws.okex_ws import OkexWsManager
+from pytradekit.ws.subscription_update import SubscriptionUpdate
+
+
+def _make_binance_manager(mocker):
+    manager = BinanceWsManager.__new__(BinanceWsManager)
+    manager._bookticker_symbols = {"BTCUSDT", "XRPUSDT"}
+    manager._subs = [
+        {
+            "method": BinanceWebSocket.subscribe.value,
+            "params": ["btcusdt@bookTicker", "xrpusdt@bookTicker"],
+        }
+    ]
+    manager.send_json = mocker.Mock()
+    return manager
+
+
+def _make_htx_manager(mocker):
+    manager = HuobiWsManager.__new__(HuobiWsManager)
+    manager._bookticker_symbols = {"BTCUSDT", "XRPUSDT"}
+    manager._subs = [
+        {"sub": "market.btcusdt.bbo", "id": 1},
+        {"sub": "market.xrpusdt.bbo", "id": 2},
+    ]
+    manager.send_json = mocker.Mock()
+    return manager
+
+
+def _make_okx_manager(mocker):
+    manager = OkexWsManager.__new__(OkexWsManager)
+    manager._bookticker_symbols = {"BTC-USDT", "XRP-USDT"}
+    manager._subs = [
+        {
+            "op": "subscribe",
+            "args": [
+                {"channel": "tickers", "instId": "BTC-USDT"},
+                {"channel": "tickers", "instId": "XRP-USDT"},
+            ],
+        }
+    ]
+    manager.send_json = mocker.Mock()
+    return manager
+
+
+def test_binance_updates_bookticker_subscriptions(mocker):
+    manager = _make_binance_manager(mocker)
+
+    update = manager.update_bookticker_stream(["BTCUSDT", "ETHUSDT"])
+
+    assert update == SubscriptionUpdate(
+        added=("ETHUSDT",),
+        removed=("XRPUSDT",),
+    )
+    assert manager.send_json.call_args_list == [
+        mocker.call(
+            {
+                "method": BinanceWebSocket.subscribe.value,
+                "params": ["ethusdt@bookTicker"],
+            }
+        ),
+        mocker.call(
+            {
+                "method": "UNSUBSCRIBE",
+                "params": ["xrpusdt@bookTicker"],
+            }
+        ),
+    ]
+    assert manager._subs == [
+        {
+            "method": BinanceWebSocket.subscribe.value,
+            "params": ["btcusdt@bookTicker", "ethusdt@bookTicker"],
+        }
+    ]
+
+
+def test_htx_updates_bookticker_subscriptions(mocker):
+    manager = _make_htx_manager(mocker)
+
+    update = manager.update_bookticker_stream(["BTCUSDT", "ETHUSDT"])
+
+    assert update == SubscriptionUpdate(
+        added=("ETHUSDT",),
+        removed=("XRPUSDT",),
+    )
+    assert manager.send_json.call_args_list == [
+        mocker.call({"sub": "market.ethusdt.bbo"}),
+        mocker.call({"unsub": "market.xrpusdt.bbo"}),
+    ]
+    assert manager._subs == [
+        {"sub": "market.btcusdt.bbo", "id": 1},
+        {"sub": "market.ethusdt.bbo", "id": 2},
+    ]
+
+
+def test_okx_updates_bookticker_subscriptions(mocker):
+    manager = _make_okx_manager(mocker)
+
+    update = manager.update_bookticker_stream(["BTC-USDT", "ETH-USDT"])
+
+    assert update == SubscriptionUpdate(
+        added=("ETH-USDT",),
+        removed=("XRP-USDT",),
+    )
+    assert manager.send_json.call_args_list == [
+        mocker.call(
+            {
+                "op": "subscribe",
+                "args": [{"channel": "tickers", "instId": "ETH-USDT"}],
+            }
+        ),
+        mocker.call(
+            {
+                "op": "unsubscribe",
+                "args": [{"channel": "tickers", "instId": "XRP-USDT"}],
+            }
+        ),
+    ]
+    assert manager._subs == [
+        {
+            "op": "subscribe",
+            "args": [
+                {"channel": "tickers", "instId": "BTC-USDT"},
+                {"channel": "tickers", "instId": "ETH-USDT"},
+            ],
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "manager_factory, symbols",
+    [
+        (_make_binance_manager, ["XRPUSDT", "BTCUSDT", "BTCUSDT"]),
+        (_make_htx_manager, ["XRPUSDT", "BTCUSDT", "BTCUSDT"]),
+        (_make_okx_manager, ["XRP-USDT", "BTC-USDT", "BTC-USDT"]),
+    ],
+)
+def test_bookticker_subscription_update_is_idempotent(
+    mocker,
+    manager_factory,
+    symbols,
+):
+    manager = manager_factory(mocker)
+
+    update = manager.update_bookticker_stream(symbols)
+
+    assert update == SubscriptionUpdate(added=(), removed=())
+    manager.send_json.assert_not_called()
+
+
+def test_bookticker_update_keeps_old_state_when_addition_fails(mocker):
+    manager = _make_binance_manager(mocker)
+    original_subscriptions = manager._subs
+    manager.send_json.side_effect = RuntimeError("connection unavailable")
+
+    with pytest.raises(RuntimeError, match="connection unavailable"):
+        manager.update_bookticker_stream(["BTCUSDT", "ETHUSDT"])
+
+    assert manager._subs is original_subscriptions
+    assert manager._bookticker_symbols == {"BTCUSDT", "XRPUSDT"}
+    assert manager.send_json.call_count == 1


### PR DESCRIPTION
## Summary

- add a shared SubscriptionUpdate result and deterministic target normalization
- add in-place add and remove APIs for Binance, HTX, and OKX book-ticker streams
- subscribe additions before removals and update reconnect state only after successful sends
- snapshot reconnect subscription lists to avoid concurrent mutation during iteration

## Impact

CEA can refresh its daily candidate universe without restarting the realtime premium service or leaving abandoned WebSocket threads.

## Test plan

- Targeted WS tests: 12 passed
- Full pytradekit suite: 251 passed, 19 warnings
- git diff --check

Required by halfshade-labs/cross_exchange_arbitrage#629.
Closes #151