### PR TITLE
Add per-venue arbitrage threshold storage

### DIFF
--- a/pytradekit/utils/dynamic_types.py
+++ b/pytradekit/utils/dynamic_types.py
@@ -1401,6 +1401,7 @@ class RedisFields(Enum):
     premium = auto()
     order_link = auto()
     arbitrage_threshold = auto()
+    arbitrage_thresholds = auto()
 
 
 class DuplicateFields(Enum):

--- a/pytradekit/utils/redis_operations.py
+++ b/pytradekit/utils/redis_operations.py
@@ -1,5 +1,6 @@
 import json
 from decimal import Decimal, InvalidOperation
+from typing import Dict, Mapping
 
 import redis
 from pytradekit.utils.dynamic_types import RedisFields
@@ -12,6 +13,29 @@ class _DecimalEncoder(json.JSONEncoder):
         if isinstance(obj, Decimal):
             return str(obj)
         return super().default(obj)
+
+
+def _normalize_arbitrage_thresholds(
+    thresholds: Mapping[str, Decimal],
+) -> Dict[str, Decimal]:
+    """Validate and normalize a venue-to-threshold mapping."""
+    if not isinstance(thresholds, Mapping) or not thresholds:
+        raise DataTypeException("Arbitrage thresholds must be a non-empty mapping")
+    normalized = {}
+    for venue, raw_threshold in thresholds.items():
+        normalized_venue = str(venue).strip().upper()
+        try:
+            threshold = Decimal(str(raw_threshold))
+        except (InvalidOperation, ValueError, TypeError) as exc:
+            raise DataTypeException(
+                f"Invalid arbitrage threshold for {normalized_venue or venue}: {raw_threshold!r}"
+            ) from exc
+        if not normalized_venue or not threshold.is_finite() or threshold < 0:
+            raise DataTypeException(
+                f"Invalid arbitrage threshold for {normalized_venue or venue}: {raw_threshold!r}"
+            )
+        normalized[normalized_venue] = threshold
+    return normalized
 
 
 TICKER_PRICE_EXPIRE_TIME = TimeConvert.MIN_TO_S * 10
@@ -411,6 +435,39 @@ class RedisOperations:
         except InvalidOperation as e:
             self.logger.debug(f"Invalid arbitrage threshold value: {value!r}", exc_info=True)
             raise DataTypeException(f"Invalid arbitrage threshold value: {value!r}") from e
+
+    def set_arbitrage_thresholds(self, thresholds: Mapping[str, Decimal]):
+        """Store atomic per-venue arbitrage thresholds under a separate key."""
+        normalized = _normalize_arbitrage_thresholds(thresholds)
+        key = RedisFields.arbitrage_thresholds.name
+        payload = json.dumps(normalized, cls=_DecimalEncoder, sort_keys=True)
+        lock = self.get_lock_for_resource(key)
+        try:
+            with lock:
+                self.client.set(key, payload)
+                self.client.expire(key, ARBITRAGE_THRESHOLD_EXPIRE_TIME)
+        except Exception as e:
+            self.logger.exception(f"Failed to set arbitrage thresholds: {e}")
+            raise DependencyException("Failed to set arbitrage thresholds") from e
+
+    def get_arbitrage_thresholds(self):
+        """Return per-venue Decimal thresholds, or None when the key is absent."""
+        key = RedisFields.arbitrage_thresholds.name
+        lock = self.get_lock_for_resource(key)
+        try:
+            with lock:
+                value = self.client.get(key)
+        except Exception as e:
+            self.logger.debug(f"Failed to get arbitrage thresholds: {e}", exc_info=True)
+            raise DependencyException("Failed to get arbitrage thresholds") from e
+        if value is None:
+            return None
+        try:
+            decoded = json.loads(value)
+            return _normalize_arbitrage_thresholds(decoded)
+        except (json.JSONDecodeError, DataTypeException, TypeError) as e:
+            self.logger.debug(f"Invalid arbitrage thresholds value: {value!r}", exc_info=True)
+            raise DataTypeException(f"Invalid arbitrage thresholds value: {value!r}") from e
 
     def ping(self):
         """Verify the Redis connection is alive. Raises DependencyException on failure."""

--- a/tests/test_redis_operations.py
+++ b/tests/test_redis_operations.py
@@ -186,6 +186,58 @@ class TestArbitrageThreshold:
         )
 
 
+class TestArbitrageThresholds:
+    def test_set_writes_normalized_json_and_expiry(self, redis_ops):
+        import json
+
+        ops, client, _ = redis_ops
+        ops.set_arbitrage_thresholds({"okx": Decimal("0.0042"), "HTX": "0.0051"})
+
+        key, payload = client.set.call_args.args
+        assert key == "arbitrage_thresholds"
+        assert json.loads(payload) == {"HTX": "0.0051", "OKX": "0.0042"}
+        client.expire.assert_called_once()
+        assert client.expire.call_args.args[0] == "arbitrage_thresholds"
+
+    def test_get_returns_decimal_mapping(self, redis_ops):
+        ops, client, _ = redis_ops
+        client.get.return_value = '{"HTX": "0.0051", "OKX": "0.0042"}'
+
+        assert ops.get_arbitrage_thresholds() == {
+            "HTX": Decimal("0.0051"),
+            "OKX": Decimal("0.0042"),
+        }
+
+    def test_get_returns_none_when_key_missing(self, redis_ops):
+        ops, client, _ = redis_ops
+        client.get.return_value = None
+
+        assert ops.get_arbitrage_thresholds() is None
+
+    @pytest.mark.parametrize(
+        "raw_value",
+        ["not-json", "[]", '{"OKX": "not-a-number"}', '{"OKX": "NaN"}'],
+    )
+    def test_get_invalid_value_raises_data_type_exception(self, redis_ops, raw_value):
+        ops, client, _ = redis_ops
+        client.get.return_value = raw_value
+
+        with pytest.raises(DataTypeException):
+            ops.get_arbitrage_thresholds()
+
+    def test_set_invalid_mapping_raises_data_type_exception(self, redis_ops):
+        ops, _, _ = redis_ops
+
+        with pytest.raises(DataTypeException):
+            ops.set_arbitrage_thresholds({"OKX": Decimal("-0.001")})
+
+    def test_get_failure_wraps_as_dependency_exception(self, redis_ops):
+        assert_wraps_as_dependency_exception(
+            redis_ops,
+            FailureSpec(client_attr="get", op_name="get_arbitrage_thresholds"),
+        )
+
+
 class TestSetOrders:
     """#118: json.dumps must use _DecimalEncoder; order payloads carry Decimal
     price/qty fields, so a plain json.dumps(value) raised TypeError (swallowed


### PR DESCRIPTION
## Summary
- add typed RedisOperations methods for venue-to-Decimal arbitrage thresholds
- store the mapping under a separate key with the existing two-day threshold TTL
- validate venue names and finite non-negative Decimal values on both write and read

## Compatibility
- the existing scalar arbitrage_threshold API is unchanged for rolling upgrades

## Tests
- 247 passed

Closes #153

Dependency of halfshade-labs/cross_exchange_arbitrage#634.