### PR TITLE
Add TTL-backed trade context helpers

### DIFF
--- a/pytradekit/utils/dynamic_types.py
+++ b/pytradekit/utils/dynamic_types.py
@@ -1400,6 +1400,7 @@ class RedisFields(Enum):
     portfolios = auto()
     premium = auto()
     order_link = auto()
+    trade_context = auto()
     arbitrage_threshold = auto()
     arbitrage_thresholds = auto()
 

--- a/pytradekit/utils/dynamic_types.py
+++ b/pytradekit/utils/dynamic_types.py
@@ -1401,6 +1401,7 @@ class RedisFields(Enum):
     premium = auto()
     order_link = auto()
     arbitrage_threshold = auto()
+    arbitrage_thresholds = auto()
 
 
 class DuplicateFields(Enum):

--- a/pytradekit/utils/redis_operations.py
+++ b/pytradekit/utils/redis_operations.py
@@ -43,6 +43,8 @@ ORDER_TICKER_EXPIRE_TIME = TimeConvert.MIN_TO_S * 30
 ORDERS_EXPIRE_TIME = TimeConvert.MIN_TO_S * 60
 PREMIUM_EXPIRE_TIME = TimeConvert.MIN_TO_S * 60 * 24 * 30
 ORDER_LINK_EXPIRE_TIME = TimeConvert.DAY_TO_S
+TRADE_CONTEXT_EXPIRE_TIME = TimeConvert.DAY_TO_S * 30
+TRADE_CONTEXT_MAX_BYTES = 64 * 1024
 # Merged portfolios snapshot for close-side premium checks; per-tick freshness
 # is validated by the reader, TTL only prevents an eternally stale key.
 PORTFOLIOS_EXPIRE_TIME = TimeConvert.MIN_TO_S * 60
@@ -372,6 +374,61 @@ class RedisOperations:
         except Exception as e:
             self.logger.exception(f"Failed to get order link for {spot_client_order_id}: {e}")
             raise DependencyException(f"Failed to get order link for {spot_client_order_id}") from e
+
+    def set_trade_context(self, trade_id: str, value: Mapping) -> None:
+        """Merge a bounded JSON context for a trade and refresh its 30-day TTL."""
+        key = self._trade_context_key(trade_id)
+        if not isinstance(value, Mapping):
+            raise DataTypeException("Trade context value must be a mapping")
+        lock = self.get_lock_for_resource(key)
+        try:
+            with lock:
+                current = self._decode_trade_context(self.client.get(key), key)
+                merged = {**current, **dict(value)}
+                payload = json.dumps(merged, cls=_DecimalEncoder, sort_keys=True)
+                if len(payload.encode("utf-8")) > TRADE_CONTEXT_MAX_BYTES:
+                    raise DataTypeException(
+                        f"Trade context exceeds {TRADE_CONTEXT_MAX_BYTES} bytes"
+                    )
+                self.client.set(key, payload)
+                self.client.expire(key, TRADE_CONTEXT_EXPIRE_TIME)
+        except DataTypeException:
+            raise
+        except Exception as e:
+            self.logger.debug(f"Failed to set trade context for {trade_id}: {e}", exc_info=True)
+            raise DependencyException(f"Failed to set trade context for {trade_id}") from e
+
+    def get_trade_context(self, trade_id: str):
+        """Return the stored trade context, or None when the key is absent."""
+        key = self._trade_context_key(trade_id)
+        lock = self.get_lock_for_resource(key)
+        try:
+            with lock:
+                raw = self.client.get(key)
+        except Exception as e:
+            self.logger.debug(f"Failed to get trade context for {trade_id}: {e}", exc_info=True)
+            raise DependencyException(f"Failed to get trade context for {trade_id}") from e
+        if raw is None:
+            return None
+        return self._decode_trade_context(raw, key)
+
+    @staticmethod
+    def _trade_context_key(trade_id: str) -> str:
+        if not isinstance(trade_id, str) or not trade_id.strip():
+            raise DataTypeException("Trade context id must be a non-empty string")
+        return f"{RedisFields.trade_context.name}:{trade_id}"
+
+    @staticmethod
+    def _decode_trade_context(raw, key: str) -> dict:
+        if raw is None:
+            return {}
+        try:
+            decoded = json.loads(raw)
+        except (json.JSONDecodeError, TypeError) as e:
+            raise DataTypeException(f"Invalid trade context JSON for {key}") from e
+        if not isinstance(decoded, dict):
+            raise DataTypeException(f"Trade context for {key} must be a JSON object")
+        return decoded
 
     def set_target_premium(self, client_order_id, premium):
         key = f"{RedisFields.premium.name}:{client_order_id}"

--- a/pytradekit/utils/redis_operations.py
+++ b/pytradekit/utils/redis_operations.py
@@ -1,5 +1,6 @@
 import json
 from decimal import Decimal, InvalidOperation
+from typing import Dict, Mapping
 
 import redis
 from pytradekit.utils.dynamic_types import RedisFields
@@ -12,6 +13,29 @@ class _DecimalEncoder(json.JSONEncoder):
         if isinstance(obj, Decimal):
             return str(obj)
         return super().default(obj)
+
+
+def _normalize_arbitrage_thresholds(
+    thresholds: Mapping[str, Decimal],
+) -> Dict[str, Decimal]:
+    """Validate and normalize a venue-to-threshold mapping."""
+    if not isinstance(thresholds, Mapping) or not thresholds:
+        raise DataTypeException("Arbitrage thresholds must be a non-empty mapping")
+    normalized = {}
+    for venue, raw_threshold in thresholds.items():
+        normalized_venue = str(venue).strip().upper()
+        try:
+            threshold = Decimal(str(raw_threshold))
+        except (InvalidOperation, ValueError, TypeError) as exc:
+            raise DataTypeException(
+                f"Invalid arbitrage threshold for {normalized_venue or venue}: {raw_threshold!r}"
+            ) from exc
+        if not normalized_venue or not threshold.is_finite() or threshold < 0:
+            raise DataTypeException(
+                f"Invalid arbitrage threshold for {normalized_venue or venue}: {raw_threshold!r}"
+            )
+        normalized[normalized_venue] = threshold
+    return normalized
 
 
 TICKER_PRICE_EXPIRE_TIME = TimeConvert.MIN_TO_S * 10
@@ -411,6 +435,39 @@ class RedisOperations:
         except InvalidOperation as e:
             self.logger.debug(f"Invalid arbitrage threshold value: {value!r}", exc_info=True)
             raise DataTypeException(f"Invalid arbitrage threshold value: {value!r}") from e
+
+    def set_arbitrage_thresholds(self, thresholds: Mapping[str, Decimal]):
+        """Store atomic per-venue arbitrage thresholds under a separate key."""
+        normalized = _normalize_arbitrage_thresholds(thresholds)
+        key = RedisFields.arbitrage_thresholds.name
+        payload = json.dumps(normalized, cls=_DecimalEncoder, sort_keys=True)
+        lock = self.get_lock_for_resource(key)
+        try:
+            with lock:
+                self.client.set(key, payload)
+                self.client.expire(key, ARBITRAGE_THRESHOLD_EXPIRE_TIME)
+        except Exception as e:
+            self.logger.exception(f"Failed to set arbitrage thresholds: {e}")
+            raise DependencyException("Failed to set arbitrage thresholds") from e
+
+    def get_arbitrage_thresholds(self):
+        """Return per-venue Decimal thresholds, or None when the key is absent."""
+        key = RedisFields.arbitrage_thresholds.name
+        lock = self.get_lock_for_resource(key)
+        try:
+            with lock:
+                value = self.client.get(key)
+        except Exception as e:
+            self.logger.debug(f"Failed to get arbitrage thresholds: {e}", exc_info=True)
+            raise DependencyException("Failed to get arbitrage thresholds") from e
+        if value is None:
+            return None
+        try:
+            decoded = json.loads(value)
+            return _normalize_arbitrage_thresholds(decoded)
+        except (json.JSONDecodeError, DataTypeException, TypeError) as e:
+            self.logger.debug(f"Invalid arbitrage thresholds value: {value!r}", exc_info=True)
+            raise DataTypeException(f"Invalid arbitrage thresholds value: {value!r}") from e
 
     def ping(self):
         """Verify the Redis connection is alive. Raises DependencyException on failure."""

--- a/tests/test_redis_operations.py
+++ b/tests/test_redis_operations.py
@@ -186,6 +186,58 @@ class TestArbitrageThreshold:
         )
 
 
+class TestArbitrageThresholds:
+    def test_set_writes_normalized_json_and_expiry(self, redis_ops):
+        import json
+
+        ops, client, _ = redis_ops
+        ops.set_arbitrage_thresholds({"okx": Decimal("0.0042"), "HTX": "0.0051"})
+
+        key, payload = client.set.call_args.args
+        assert key == "arbitrage_thresholds"
+        assert json.loads(payload) == {"HTX": "0.0051", "OKX": "0.0042"}
+        client.expire.assert_called_once()
+        assert client.expire.call_args.args[0] == "arbitrage_thresholds"
+
+    def test_get_returns_decimal_mapping(self, redis_ops):
+        ops, client, _ = redis_ops
+        client.get.return_value = '{"HTX": "0.0051", "OKX": "0.0042"}'
+
+        assert ops.get_arbitrage_thresholds() == {
+            "HTX": Decimal("0.0051"),
+            "OKX": Decimal("0.0042"),
+        }
+
+    def test_get_returns_none_when_key_missing(self, redis_ops):
+        ops, client, _ = redis_ops
+        client.get.return_value = None
+
+        assert ops.get_arbitrage_thresholds() is None
+
+    @pytest.mark.parametrize(
+        "raw_value",
+        ["not-json", "[]", '{"OKX": "not-a-number"}', '{"OKX": "NaN"}'],
+    )
+    def test_get_invalid_value_raises_data_type_exception(self, redis_ops, raw_value):
+        ops, client, _ = redis_ops
+        client.get.return_value = raw_value
+
+        with pytest.raises(DataTypeException):
+            ops.get_arbitrage_thresholds()
+
+    def test_set_invalid_mapping_raises_data_type_exception(self, redis_ops):
+        ops, _, _ = redis_ops
+
+        with pytest.raises(DataTypeException):
+            ops.set_arbitrage_thresholds({"OKX": Decimal("-0.001")})
+
+    def test_get_failure_wraps_as_dependency_exception(self, redis_ops):
+        assert_wraps_as_dependency_exception(
+            redis_ops,
+            FailureSpec(client_attr="get", op_name="get_arbitrage_thresholds"),
+        )
+
+
 class TestSetOrders:
     """#118: json.dumps must use _DecimalEncoder; order payloads carry Decimal
     price/qty fields, so a plain json.dumps(value) raised TypeError (swallowed

--- a/tests/test_redis_operations.py
+++ b/tests/test_redis_operations.py
@@ -106,6 +106,74 @@ class TestGetTargetPremium:
         )
 
 
+class TestTradeContext:
+    def test_set_serializes_decimal_and_applies_ttl(self, redis_ops):
+        import json
+        from pytradekit.utils.redis_operations import TRADE_CONTEXT_EXPIRE_TIME
+
+        ops, client, _ = redis_ops
+        client.get.return_value = None
+
+        ops.set_trade_context("trade-1", {"entry": {"perp_bid": Decimal("1.25")}})
+
+        key, payload = client.set.call_args.args
+        assert key == "trade_context:trade-1"
+        assert json.loads(payload) == {"entry": {"perp_bid": "1.25"}}
+        client.expire.assert_called_once_with(key, TRADE_CONTEXT_EXPIRE_TIME)
+
+    def test_set_merges_top_level_sections(self, redis_ops):
+        import json
+
+        ops, client, _ = redis_ops
+        client.get.return_value = '{"entry": {"perp_bid": "1.25"}}'
+
+        ops.set_trade_context("trade-1", {"close": {"perp_ask": Decimal("1.20")}})
+
+        stored = json.loads(client.set.call_args.args[1])
+        assert stored == {
+            "entry": {"perp_bid": "1.25"},
+            "close": {"perp_ask": "1.20"},
+        }
+
+    def test_get_returns_mapping(self, redis_ops):
+        ops, client, _ = redis_ops
+        client.get.return_value = '{"entry": {"spot_ask": "1.10"}}'
+
+        assert ops.get_trade_context("trade-1") == {
+            "entry": {"spot_ask": "1.10"}
+        }
+
+    def test_get_missing_returns_none(self, redis_ops):
+        ops, client, _ = redis_ops
+        client.get.return_value = None
+
+        assert ops.get_trade_context("trade-1") is None
+
+    @pytest.mark.parametrize("raw", ["not-json", "[]"])
+    def test_malformed_payload_raises_data_type_exception(self, redis_ops, raw):
+        ops, client, _ = redis_ops
+        client.get.return_value = raw
+
+        with pytest.raises(DataTypeException):
+            ops.get_trade_context("trade-1")
+
+    def test_invalid_value_raises_data_type_exception(self, redis_ops):
+        ops, _, _ = redis_ops
+
+        with pytest.raises(DataTypeException):
+            ops.set_trade_context("trade-1", ["not", "a", "mapping"])
+
+    def test_client_failure_wraps_as_dependency_exception(self, redis_ops):
+        assert_wraps_as_dependency_exception(
+            redis_ops,
+            FailureSpec(
+                client_attr="get",
+                op_name="get_trade_context",
+                op_args=("trade-1",),
+            ),
+        )
+
+
 class TestSetPortfolios:
     """CEA#472: the stored key must accumulate symbols (merge), publish only the
     delta, and carry a TTL so a quiet market cannot serve an eternal snapshot."""


### PR DESCRIPTION
Closes #155

## Summary
- add a dedicated Redis trade_context namespace with 30-day TTL
- expose set_trade_context/get_trade_context through RedisOperations
- merge top-level entry and close sections atomically under the existing Redis lock pattern
- serialize Decimal values as strings and reject malformed, non-object, or oversized payloads
- wrap Redis failures in DependencyException and malformed data in DataTypeException

## Tests
- focused Redis suite: 50 passed
- full suite: 255 passed
- git diff --check

## Stack
This dependency PR is stacked on #154 and is consumed by halfshade-labs/cross_exchange_arbitrage#645.